### PR TITLE
update README to note installing and running migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Just add this line to your Gemfile:
 
 Then run `bundle install`. Authentication will then work exactly as it did in previous versions of Spree.
 
-If you're installing this in a new Spree 1.2+ application, you'll need to run `bundle exec rake spree_auth:admin:create` in order to set up the admin user for the application.
+If you're installing this in a new Spree 1.2+ application, you'll need to install and run the migrations with
+
+    bundle exec rake spree_auth:install:migrations
+    bundle exec rake db:migrate
+    
+and then, run `bundle exec rake spree_auth:admin:create` in order to set up the admin user for the application.
 
 
 ## Testing


### PR DESCRIPTION
in a new app, the migrations need to be run or you'll get "undefined method `password_salt=' for #Spree::User:0x00000006f02728" from devise
