### PR TITLE
migrations: don't try to remove index 'email_idx' on spree_users

### DIFF
--- a/db/migrate/20120605211305_make_users_email_index_unique.rb
+++ b/db/migrate/20120605211305_make_users_email_index_unique.rb
@@ -1,11 +1,9 @@
 class MakeUsersEmailIndexUnique < ActiveRecord::Migration
   def up
-    remove_index "spree_users", :name => "email_idx"
     add_index "spree_users", ["email"], :name => "email_idx", :unique => true
   end
 
   def down
     remove_index "spree_users", :name => "email_idx"
-    add_index "spree_users", ["email"], :name => "email_idx"
   end
 end


### PR DESCRIPTION
I'm not 100% sure of the background (ie, at what point this index was ever created to begin with), but if this is a new Spree 1.2 app then it doesn't exist and therefore attempts to remove it are fatal.
