### PR TITLE
Change default redirect to root_path

### DIFF
--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -20,7 +20,7 @@ class Spree::UserSessionsController < Devise::SessionsController
       respond_to do |format|
         format.html {
           flash.notice = t(:logged_in_succesfully)
-          redirect_back_or_default(products_path)
+          redirect_back_or_default(root_path)
         }
         format.js {
           user = resource.record


### PR DESCRIPTION
Feel free to ignore this pull request if you like, but I thought it made sense for the default redirect on login to point the customer to the homepage.
