### PR TITLE
support spree #1851 where header is refactor for easy deface override

### DIFF
--- a/app/overrides/auth_shared_login_bar.rb
+++ b/app/overrides/auth_shared_login_bar.rb
@@ -1,4 +1,4 @@
-Deface::Override.new(:virtual_path => "spree/shared/_nav_bar",
+Deface::Override.new(:virtual_path => "spree/shared/_header",
                      :name => "auth_shared_login_bar",
                      :insert_before => "li#search-bar",
                      :partial => "spree/shared/login_bar",


### PR DESCRIPTION
header in spree is refactored to easy override with deface where people can move links between nav-bar and main-nav-bar. So login partial will be added to header rather than nav-bar partial (as it is removed.)

spree change is not merged in it but if it does here is a fix for login link.
