### PR TITLE
Fix current_order assignment to current_user - taken form spree_auth 1.1.3

### DIFF
--- a/app/models/spree/current_order_decorator.rb
+++ b/app/models/spree/current_order_decorator.rb
@@ -1,4 +1,9 @@
 Spree::Core::CurrentOrder.module_eval do
+  # Associate the new order with the currently authenticated user before saving
+  def before_save_new_order
+    @current_order.user ||= try_spree_current_user
+  end
+
   def after_save_new_order
     # make sure the user has permission to access the order (if they are a guest)
     return if spree_current_user


### PR DESCRIPTION
Hi,

I had an issue, that order wasn't assigned to current_user. I saw the hook before_save_new_order was present in previous version of the gem, but it was removed. I'm not sure why?

To reproduce the issue login, and try to make an order.

I'm using:
spree from git://github.com/spree/spree.git
spree_auth_devise from git://github.com/spree/spree_auth_devise
