### PR TITLE
Invalid Order total in account view

### DIFF
--- a/app/views/spree/users/show.html.erb
+++ b/app/views/spree/users/show.html.erb
@@ -30,7 +30,7 @@
           <td class="order-status"><%= t(order.state).titleize %></td>
           <td class="order-payment-state"><%= t("payment_states.#{order.payment_state}") if order.payment_state %></td>
           <td class="order-shipment-state"><%= t("shipment_states.#{order.shipment_state}") if order.shipment_state %></td>
-          <td class="order-total"><%= number_to_currency order.total %></td>
+          <td class="order-total"><%= order.display_total %></td>
         </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
Calling `number_to_currency(order.total)` is not correct in Spree (it needs to be multiplied by 100).

It should be `Spree::Money.new(order.total)` or more simply `order.display_total` which is the same.
