### PR TITLE
current_order_decorator changed to order_decorator

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,4 +1,4 @@
-Spree::Core::CurrentOrder.module_eval do
+Spree::Core::ControllerHelpers::Order.module_eval do
   # Associate the new order with the currently authenticated user before saving
   def before_save_new_order
     @current_order.user ||= try_spree_current_user


### PR DESCRIPTION
As per the commit in the master branch of spree(https://github.com/spree/spree/commit/1cd005c5241d031ecb260ce41b744251d9d3544f#core/lib/spree/core.rb)  I see Spree::Core::CurrentOrder has been replaced with Spree::Core::ControllerHelpers::Order. So, when I added this repository as gem in my Gemfile. 

Everything was fine until I said: `rails generate --help` or `rails s`. Every command inside the application was throwing this error:  `NameError: uninitialized constant Spree::Core::CurrentOrder`

Now, when I changed the referring module name. Everything Works Out the Way It's Suppose To..

Let me know if I am missing anything here :question: 
