### PR TITLE
update gemspec to use cancan 1.6.8

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_core'
   s.add_dependency 'devise', '~> 2.0.4'
-  s.add_dependency 'cancan', '= 1.6.7'
+  s.add_dependency 'cancan', '= 1.6.8'
 end


### PR DESCRIPTION
This is just updating the version of cancan. This will let me bundle update spree without bundler complaining that there is no compatible version of cancan. The tests do not pass, but they are the same failing 9 tests as can be found in [this build](https://travis-ci.org/spree/spree_auth_devise/jobs/3732515).
