### PR TITLE
require devise-encryptable dependency

### DIFF
--- a/lib/spree/auth/devise.rb
+++ b/lib/spree/auth/devise.rb
@@ -1,5 +1,6 @@
 require 'spree/core'
 require 'devise'
+require 'devise-encryptable'
 require 'cancan'
 
 module Spree


### PR DESCRIPTION
the gem dependency devise-encryptable should be required from this gem to avoid having to add it to the Gemfile.
