### PR TITLE
Require devise-encryptable in engine so main app doesn't have to add to ...

### DIFF
--- a/lib/spree/auth/devise.rb
+++ b/lib/spree/auth/devise.rb
@@ -1,5 +1,6 @@
 require 'spree/core'
 require 'devise'
+require 'devise-encryptable'
 require 'cancan'
 
 module Spree


### PR DESCRIPTION
...Gemfile.

When trying to use Spree master w/spree_auth_devise master you must add devise-encryptable to your Gemfile since spree_auth_devise only states that it is a dependency, but doesn't load it.

This is what you run into w/fresh app:

```
JDutil@Jeffs-MacBook-Pro ~/tmp_2_0$ rails s                                                                                                                                                    ‹1.9.3-p327›
=> Booting WEBrick
=> Rails 3.2.11 application starting in development on http://0.0.0.0:3000
=> Call with -d to detach
=> Ctrl-C to shutdown server
[DEVISE] You're trying to include :encryptable in your model but it is not bundled with the Devise gem anymore. Please add `devise-encryptable` to your Gemfile to proceed.

[DEVISE] You're trying to include :encryptable in your model but it is not bundled with the Devise gem anymore. Please add `devise-encryptable` to your Gemfile to proceed.

[DEVISE] You're trying to include :encryptable in your model but it is not bundled with the Devise gem anymore. Please add `devise-encryptable` to your Gemfile to proceed.

Exiting
/usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:97:in `const_get': uninitialized constant Devise::Models::Encryptable (NameError)
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:97:in `block (2 levels) in devise'
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:92:in `each'
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:92:in `block in devise'
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:123:in `devise_modules_hook!'
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:90:in `devise'
    from /Users/JDutil/spree_auth_devise/app/models/spree/user.rb:5:in `<class:User>'
    from /Users/JDutil/spree_auth_devise/app/models/spree/user.rb:2:in `<module:Spree>'
    from /Users/JDutil/spree_auth_devise/app/models/spree/user.rb:1:in `<top (required)>'
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/activesupport-3.2.11/lib/active_support/inflector/methods.rb:230:in `block in constantize'
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/activesupport-3.2.11/lib/active_support/inflector/methods.rb:229:in `each'
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/activesupport-3.2.11/lib/active_support/inflector/methods.rb:229:in `constantize'
    from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/activesupport-3.2.11/lib/active_support/core_ext/string/inflections.rb:54:in `constantize'
    from /Users/JDutil/spree/core/lib/spree/core.rb:53:in `user_class'
```

Requiring encryptable in the extension will make setup easier for users by not requiring you to add it to your Gemfile.  Similar to this with spree_active_shipping requiring active_shipping so you don't need it in your Gemfile:
https://github.com/spree/spree_active_shipping/blob/master/lib/spree_active_shipping.rb#L2
