### PR TITLE
Bump Devise version.

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core'
-  s.add_dependency 'devise', '~> 2.2.2'
+  s.add_dependency 'devise', '~> 2.2.3'
   s.add_dependency 'devise-encryptable', '0.1.1'
   s.add_dependency 'cancan', '~> 1.6.7'
 end


### PR DESCRIPTION
Bump Devise to 2.2.3 for an important security update.

Announcement:
http://blog.plataformatec.com.br/2013/01/security-announcement-devise-v2-2-3-v2-1-3-v2-0-5-and-v1-5-3-released/
