### PR TITLE
Fix for double order creation

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -1,5 +1,6 @@
 class Spree::UsersController < Spree::StoreController
   ssl_required
+  skip_before_filter :set_current_order, :only => :show
   prepend_before_filter :load_object, :only => [:show, :edit, :update]
   prepend_before_filter :authorize_actions, :only => :new
 


### PR DESCRIPTION
After the Spree::UsersController was modified to inherit from Spree::StoreController it inherited its before_filters including the set_current_order filter. The effect of this filter is to create an order in the database under certain conditions, in particular when there is no session[:order_id].

Once a user completes an order Spree clears the order_id session meaning that as soon as the user is redirected to the user#show page the set_current_order file creates a second order.

If you follow the logic of the set_current_order filter here you'll see what I mean:
https://github.com/spree/spree/blob/master/core/lib/spree/core/controller_helpers/order.rb

Seeing as the ability to run tests was down due to the issue with `undefined method`add_module' for Devise:Module` I haven't been able to run tests on the repository, although I can confirm it works within my website.
