### PR TITLE
Address state is required (and shouldn't be)

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -12,7 +12,7 @@ if defined?(Spree::CheckoutController)
     def update_registration
       fire_event("spree.user.signup", :order => current_order)
       # hack - temporarily change the state to something other than cart so we can validate the order email address
-      current_order.state = 'address'
+      current_order.state = current_order.checkout_steps.first
       if current_order.update_attributes(params[:order])
         redirect_to checkout_path
       else


### PR DESCRIPTION
Email validation in checkout controller decorator assumes the 
`address` state will be the present. Changed to use the first
checkout step via `current_order.checkout_steps.first`.
