### PR TITLE
Fix on_hand behavior to be compatible with changes in Spree master

### DIFF
--- a/spec/requests/checkout_spec.rb
+++ b/spec/requests/checkout_spec.rb
@@ -17,8 +17,8 @@ describe "Checkout", :js => true do
 
   before do
     @product = create(:product, :name => "RoR Mug")
-    @product.on_hand = 1
-    @product.save
+    v = @product.variants.create!(sku: 'ROR1')
+    v.stock_items.first.update_column(:count_on_hand, 1)
 
     visit spree.root_path
   end

--- a/spec/requests/promotion_adjustment_spec.rb
+++ b/spec/requests/promotion_adjustment_spec.rb
@@ -20,8 +20,8 @@ describe 'promotion adjustments', :js => true do
 
   before do
     @product = create(:product, :name => "RoR Mug")
-    @product.on_hand = 1
-    @product.save
+    v = @product.variants.create!(sku: 'ROR2')
+    v.stock_items.first.update_column(:count_on_hand, 1)
 
     sign_in_as!(user)
     visit spree.admin_path


### PR DESCRIPTION
I'm getting errors in the spec run because the spec setup code sets on_hand directly on a Spree::Product object.  This behavior has changed, so I've updated the code to create a variant and to set on_hand value in the stock items.
