### PR TITLE
Update to accomodate change in admin routes

### DIFF
--- a/app/controllers/spree/admin/orders/admin_orders_customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/admin_orders_customer_details_controller_decorator.rb
@@ -1,0 +1,18 @@
+require 'spree/admin/orders/customer_details_controller'
+
+if defined?(Spree::Admin::Orders::CustomerDetailsController)
+  Spree::Admin::Orders::CustomerDetailsController.class_eval do
+    before_filter :check_authorization
+
+    private
+      def check_authorization
+        load_order
+        session[:access_token] ||= params[:token]
+
+        resource = @order || Spree::Order.new
+        action = params[:action].to_sym
+
+        authorize! action, resource, session[:access_token]
+      end
+  end
+end

--- a/spec/requests/admin_permissions_spec.rb
+++ b/spec/requests/admin_permissions_spec.rb
@@ -23,8 +23,9 @@ describe "Admin Permissions" do
     end
 
     it "should not be able to view an order" do
-      create(:order, :number => "R123")
-      visit spree.admin_order_path("R123")
+      number = "R123"
+      create(:order, :number => number)
+      visit "admin/orders/#{number}/customer"
       page.should have_content("Authorization Failure")
     end
   end


### PR DESCRIPTION
In Spree Backend the Admin::OrdersController#show route had been removed and replaced with a route on a new controller, Admin::Orders::CustomerDetails#show.  Updated the code to accomodate this change and updated the corresponding test.

After this is merged it's probably worth looking at the admin code in more detail, to ensure all order related routes are secured.
