### PR TITLE
Dont automatically assign admin role.

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -9,7 +9,6 @@ module Spree
     belongs_to :ship_address, :foreign_key => 'ship_address_id', :class_name => 'Spree::Address'
     belongs_to :bill_address, :foreign_key => 'bill_address_id', :class_name => 'Spree::Address'
 
-    before_save :check_admin
     before_validation :set_login
     before_destroy :check_completed_orders
 
@@ -54,12 +53,6 @@ module Spree
 
       def check_completed_orders
         raise DestroyWithOrdersError if orders.complete.present?
-      end
-
-      def check_admin
-        return if self.class.admin_created?
-        admin_role = Role.find_or_create_by_name 'admin'
-        self.spree_roles << admin_role
       end
 
       def set_login

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,23 +44,4 @@ describe Spree::User do
     end
   end
 
-  context '#save' do
-    let(:user) { build(:user) }
-
-    context 'when there are no admin users' do
-      it 'should assign the user an admin role' do
-        user.save
-        user.has_spree_role?('admin').should be_true
-      end
-    end
-
-    context 'when there are existing admin users' do
-      before { create(:admin_user) }
-
-      it 'should not assign the user an admin role' do
-        user.save
-        user.has_spree_role?('anonymous?').should be_false
-      end
-    end
-  end
 end


### PR DESCRIPTION
I'd prefer an admin role is not automatically assigned if there are no admin users already.  There is a rake task that can be used to create an admin or it can be done during installation.

This prevents confusion I ran into when writing extension specs.  I would be calling the user factory to test a feature that normal users should not have access to.  The check_admin callback would end up setting the admin role on the user, and cause my spec to fail.  I end up needing to create 2 users just to test a non admin circumstance without removing this callback.
