### PR TITLE
added error messages to reset password page

### DIFF
--- a/app/views/spree/user_passwords/new.html.erb
+++ b/app/views/spree/user_passwords/new.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @user } %>
+
 <div id="forgot-password">
   <h6><%= t(:forgot_password) %></h6>
 


### PR DESCRIPTION
I added the missing error messages to the reset password page.
