### PR TITLE
Update the original def for admin_tabs override and hide it for those without authorization

### DIFF
--- a/app/overrides/admin_tab.rb
+++ b/app/overrides/admin_tab.rb
@@ -1,7 +1,7 @@
 Deface::Override.new(:virtual_path => "spree/layouts/admin",
                      :name => "user_admin_tabs",
                      :insert_bottom => "[data-hook='admin_tabs'], #admin_tabs[data-hook]",
-                     :text => "<%= tab(:users, :url => spree.admin_users_path, :icon => 'icon-user') %>",
-                     :disabled => false,
-                     :original => 'e49127029c733dcaf154ad0bd59102b63c57ac0b')
+:text => "<% if can? :admin, Spree::User %><%= tab(:users, :url => spree.admin_users_path, :icon => 'icon-user') %><% end %>",
+                     :disabled => false) #,
+                     #:original => 'e49127029c733dcaf154ad0bd59102b63c57ac0b')
 


### PR DESCRIPTION
Pretty much what the title says. Perhaps this override should be moved to a .html.erb.deface file? Also, maybe it should override the partial at `spree/backend/app/views/spree/admin/shared/_tabs.html.erb` instead of the layout file?

Anyway, this patch fixes the error message and checks for auth like the rest of the tabs in the partial.
