### PR TITLE
Add logout path to routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Spree::Core::Engine.routes.prepend do
 
   devise_scope :user do
     get '/login' => 'user_sessions#new', :as => :login
+    get '/logout' => 'user_sessions#new', :as => :logout
     get '/signup' => 'user_registrations#new', :as => :signup
   end
 


### PR DESCRIPTION
store_location within auth.rb would throw an exception since spree.logout_path (via spree_logout_path) is not defined. I enabled store_location using :after_filter :store_location in my application_controller.rb
