### PR TITLE
Set user_mailer to use Spree::BaseMailer to mimic OrderMailer and Shipme...

### DIFF
--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -1,8 +1,8 @@
-class Spree::UserMailer < ActionMailer::Base
+class Spree::UserMailer < Spree::BaseMailer
   def reset_password_instructions(user)
     @edit_password_reset_url = spree.edit_spree_user_password_url(:reset_password_token => user.reset_password_token)
 
-    mail(:to => user.email, :from => Spree::Config[:emails_sent_from],
+    mail(:to => user.email, :from => from_address,
          :subject => Spree::Config[:site_name] + ' ' + I18n.t(:password_reset_instructions))
   end
 end


### PR DESCRIPTION
...ntMailer

Set mail :from to from_address method from the base mailer, so that it will use the email in the current MailMethod
