### PR TITLE
redirect_back_or_default ain't working

### DIFF
--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -48,7 +48,7 @@ class Spree::UserSessionsController < Devise::SessionsController
     end
 
     def redirect_back_or_default(default)
-      redirect_to(session["user_return_to"] || default)
-      session["user_return_to"] = nil
+      redirect_to(session["spree_user_return_to"] || default)
+      session["spree_user_return_to"] = nil
     end
 end


### PR DESCRIPTION
App is not redirecting to session['user_return_to'] since the session variable is set to session['spree_user_return_to'].(But I don't know from where that is happening)
