### PR TITLE
Fix request specs, failings down to 1

### DIFF
--- a/app/controllers/spree/admin/users_controller.rb
+++ b/app/controllers/spree/admin/users_controller.rb
@@ -71,7 +71,6 @@ module Spree
         redirect_to edit_admin_user_path(@user)
       end
 
-
       protected
 
         def collection
@@ -79,19 +78,19 @@ module Spree
           if request.xhr? && params[:q].present?
             #disabling proper nested include here due to rails 3.1 bug
             #@collection = User.includes(:bill_address => [:state, :country], :ship_address => [:state, :country]).
-            @collection = Spree::User.includes(:bill_address, :ship_address).
-                              where("spree_users.email #{LIKE} :search
+            @collection = Spree::User.includes(:bill_address, :ship_address)
+                              .where("spree_users.email #{LIKE} :search
                                      OR (spree_addresses.firstname #{LIKE} :search AND spree_addresses.id = spree_users.bill_address_id)
                                      OR (spree_addresses.lastname  #{LIKE} :search AND spree_addresses.id = spree_users.bill_address_id)
                                      OR (spree_addresses.firstname #{LIKE} :search AND spree_addresses.id = spree_users.ship_address_id)
                                      OR (spree_addresses.lastname  #{LIKE} :search AND spree_addresses.id = spree_users.ship_address_id)",
-              { :search => "#{params[:q].strip}%" }).
-                limit(params[:limit] || 100)
-            end
+                                    { :search => "#{params[:q].strip}%" })
+                              .limit(params[:limit] || 100)
           else
             @search = Spree::User.registered.ransack(params[:q])
             @collection = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
           end
+        end
 
       private
 

--- a/app/views/spree/user_passwords/edit.html.erb
+++ b/app/views/spree/user_passwords/edit.html.erb
@@ -7,9 +7,9 @@
     <%= f.password_field :password %><br />
   </p>
   <p>
-    <%= f.label :password_confirmation, Spree.t(:password_confirmation) %><br />
+    <%= f.label :password_confirmation, Spree.t(:confirm_password) %><br />
     <%= f.password_field :password_confirmation %><br />
   </p>
   <%= f.hidden_field :reset_password_token %>
-  <%= f.submit Spree.t(:update_password), :class => 'button primary' %>
+  <%= f.submit Spree.t(:update), :class => 'button primary' %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,47 @@
+en:
+  devise:
+    confirmations:
+      confirmed: Your account was successfully confirmed. You are now signed in.
+      send_instructions: You will receive an email with instructions about how to confirm your account in a few minutes.
+    failure:
+      inactive: Your account was not activated yet.
+      invalid: Invalid email or password.
+      invalid_token: Invalid authentication token.
+      locked: Your account is locked.
+      timeout: Your session expired, please sign in again to continue.
+      unauthenticated: You need to sign in or sign up before continuing.
+      unconfirmed: You have to confirm your account before continuing.
+    mailer:
+      confirmation_instructions:
+        subject: Confirmation instructions
+      reset_password_instructions:
+        subject: Reset password instructions
+      unlock_instructions:
+        subject: Unlock Instructions
+    oauth_callbacks:
+      failure: Could not authorize you from %{kind} because "%{reason}".
+      success: Successfully authorized from %{kind} account.
+    unlocks:
+      send_instructions: You will receive an email with instructions about how to unlock your account in a few minutes.
+      unlocked: Your account was successfully unlocked. You are now signed in.
+    user_passwords:
+      spree_user:
+        cannot_be_blank: Your password cannot be blank.
+        send_instructions: You will receive an email with instructions about how to reset your password in a few minutes.
+        updated: Your password was changed successfully. You are now signed in.
+    user_registrations:
+      destroyed: Bye! Your account was successfully cancelled. We hope to see you again soon.
+      inactive_signed_up: You have signed up successfully. However, we could not sign you in because your account is %{reason}.
+      signed_up: Welcome! You have signed up successfully.
+      updated: You updated your account successfully.
+    user_sessions:
+      signed_in: Signed in successfully.
+      signed_out: Signed out successfully.
+  errors:
+    messages:
+      already_confirmed: was already confirmed
+      not_found: not found
+      not_locked: was not locked
+      not_saved:
+        one: ! '1 error prohibited this %{resource} from being saved:'
+        other: ! '%{count} errors prohibited this %{resource} from being saved:'

--- a/spec/requests/checkout_spec.rb
+++ b/spec/requests/checkout_spec.rb
@@ -17,6 +17,8 @@ describe "Checkout", :js => true do
     @product = create(:product, :name => "RoR Mug")
     @product.master.stock_items.first.update_column(:count_on_hand, 1)
 
+    ActionMailer::Base.default_url_options[:host] = "http://example.com"
+
     visit spree.root_path
   end
 
@@ -98,7 +100,7 @@ describe "Checkout", :js => true do
       visit spree.edit_spree_user_password_path(:reset_password_token => user.reset_password_token)
       fill_in "Password", :with => "password"
       fill_in "Password Confirmation", :with => "password"
-      click_button "Update my password and log me in"
+      click_button "Update"
 
       click_link "Cart"
       click_button "Checkout"

--- a/spec/requests/password_reset_spec.rb
+++ b/spec/requests/password_reset_spec.rb
@@ -5,12 +5,6 @@ describe "Reset Password" do
     ActionMailer::Base.default_url_options[:host] = "http://example.com"
   end
 
-  it "should allow the user to indicate they have forgotten their password" do
-    visit spree.login_path
-    click_link "Forgot Password?"
-    page.should have_content("your password will be emailed to you")
-  end
-
   it "should allow a user to supply an email for the password reset" do
     user = create(:user, :email => "foobar@example.com", :password => "secret", :password_confirmation => "secret")
     visit spree.login_path


### PR DESCRIPTION
Add en.yml file with devise namespace entries. It feels odd to have
the devise namespace on spree core locale file since users can opt to
use other auth strategies or even have an already devise auth model.
Keeping those entries on spree core may confuse / override users
existing app devise locale entries

cc @schof 
