### PR TITLE
master branch now depends on spree 2.1.0.beta

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '~> 2.0.0.beta'
+  spree_version = '~> 2.1.0.beta'
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_frontend', spree_version
   s.add_dependency 'spree_backend', spree_version


### PR DESCRIPTION
To reflect current version on spree/master
