### PR TITLE
use Spree.t on order.state

### DIFF
--- a/app/views/spree/users/show.html.erb
+++ b/app/views/spree/users/show.html.erb
@@ -27,7 +27,7 @@
         <tr class="<%= cycle('even', 'odd') %>">
           <td class="order-number"><%= link_to order.number, order_url(order) %></td>
           <td class="order-date"><%= l order.completed_at.to_date %></td>
-          <td class="order-status"><%= t(order.state).titleize %></td>
+          <td class="order-status"><%= Spree.t(order.state).titleize %></td>
           <td class="order-payment-state"><%= Spree.t("payment_states.#{order.payment_state}") if order.payment_state %></td>
           <td class="order-shipment-state"><%= Spree.t("shipment_states.#{order.shipment_state}") if order.shipment_state %></td>
           <td class="order-total"><%= money order.total %></td>


### PR DESCRIPTION
fixes the issue of the order state showing as "Translation Missing".
![order-state-localization](https://f.cloud.github.com/assets/71225/562620/a09de7ea-c4af-11e2-8243-70fdec38ee82.png)
