### PR TITLE
Bump devise to 2.2.5

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_frontend', spree_version
   s.add_dependency 'spree_backend', spree_version
-  s.add_dependency 'devise', '~> 2.2.3'
+  s.add_dependency 'devise', '~> 2.2.5'
   s.add_dependency 'devise-encryptable', '0.1.2'
   s.add_dependency 'cancan', '~> 1.6.7'
 end


### PR DESCRIPTION
Bring fix for CSRF token fixation attacks as described in
http://blog.plataformatec.com.br/2013/08/csrf-token-fixation-attacks-in-devise/
