### PR TITLE
Minor spec changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem 'shoulda-matchers', '~> 1.4.2'
   gem 'capybara', '~> 2.1'
   gem 'database_cleaner', '~> 1.0.1'
-  gem 'selenium-webdriver', '2.33.0'
+  gem 'selenium-webdriver', '2.35.0'
   gem 'launchy'
 end
 

--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -57,7 +57,7 @@ def create_admin_user
   else
     admin = Spree::User.new(attributes)
     if admin.save
-      role = Spree::Role.find_or_create_by_name 'admin'
+      role = Spree::Role.find_or_create_by(name: 'admin')
       admin.spree_roles << role
       admin.save
       say "Done!"

--- a/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/spec/controllers/spree/admin/users_controller_spec.rb
@@ -21,14 +21,14 @@ describe Spree::Admin::UsersController do
     end
 
     it "allows admins to update a user's API key" do
-      user.spree_roles << Spree::Role.find_or_create_by_name('admin')
+      user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
       mock_user.should_receive(:generate_spree_api_key!).and_return(true)
       spree_put :generate_api_key, :id => mock_user.id
       response.should redirect_to(spree.edit_admin_user_path(mock_user))
     end
 
     it "allows admins to clear a user's API key" do
-      user.spree_roles << Spree::Role.find_or_create_by_name('admin')
+      user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
       mock_user.should_receive(:clear_spree_api_key!).and_return(true)
       spree_put :clear_api_key, :id => mock_user.id
       response.should redirect_to(spree.edit_admin_user_path(mock_user))

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Orders" do
+describe "Orders", :js => true do
   it "should allow a user to view their cart at any time" do
     visit spree.cart_path
     page.should have_content("Your cart is empty")


### PR DESCRIPTION
A few small changes to the specs.
1. Addressed deprecation warnings.  
2. Upgraded selenium webdriver version.
3. Added a 'js' flag to a feature spec

Note that while looking at these issues, I discovered that a recent change in spree_core appears to have caused a regression in the spree_auth_devise gem.  There is a failing spec on this gem that appears to be a result of this change to spree_core

In spree_core the created_by_id attribute was added to Spree::Order and is now being used to look up Spree::User.last_incomplete_spree_order.  But this attribute is not being set if the user authenticates after the current_order is created.  This looks like something that needs to be added to associated_user
