### PR TITLE
Support Asynchronous Mailers

### DIFF
--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -1,9 +1,10 @@
 module Spree
   class UserMailer < BaseMailer
     def reset_password_instructions(user)
-      @edit_password_reset_url = spree.edit_spree_user_password_url(:reset_password_token => user.reset_password_token)
+      recipient = user.respond_to?(:id) ? user : Spree.user_class.find(user)
+      @edit_password_reset_url = spree.edit_spree_user_password_url(:reset_password_token => recipient.reset_password_token)
 
-      mail(:to => user.email, :from => from_address,
+      mail(:to => recipient.email, :from => from_address,
           :subject => Spree::Config[:site_name] + ' ' + 
             I18n.t(:subject, :scope => [:devise, :mailer, :reset_password_instructions]))
     end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -45,7 +45,7 @@ module Spree
 
     def send_reset_password_instructions
       generate_reset_password_token!
-      UserMailer.reset_password_instructions(self).deliver
+      UserMailer.reset_password_instructions(self.id).deliver
     end
 
     protected

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,32 +1,45 @@
 require 'spec_helper'
 
-describe Spree::UserMailer do 
+describe Spree::UserMailer do
+  let(:user) { create(:user) }
 
   before do
     ActionMailer::Base.default_url_options[:host] = "http://example.com"
-    user = create(:user)
-    Spree::UserMailer.reset_password_instructions(user).deliver
-    @message = ActionMailer::Base.deliveries.last
   end
 
-  describe '#reset_password_instructions' do 
-    context 'subject includes' do 
-      it 'translated devise instructions' do 
-        @message.subject.should include(
-          I18n.t(:subject, :scope => [:devise, :mailer, :reset_password_instructions])
-        )
+  describe '#reset_password_instructions' do
+    describe 'message contents' do
+      before do
+        Spree::UserMailer.reset_password_instructions(user.id).deliver
+        @message = ActionMailer::Base.deliveries.last
       end
 
-      it 'Spree site name' do 
-        @message.subject.should include(Spree::Config[:site_name])
-      end
-    end  
+      context 'subject includes' do
+        it 'translated devise instructions' do 
+          @message.subject.should include(
+            I18n.t(:subject, :scope => [:devise, :mailer, :reset_password_instructions])
+          )
+        end
 
-    context 'body includes' do
-      it 'password reset url' do
-        @message.body.raw_source.should include('http://example.com/user/spree_user/password/edit')
+        it 'Spree site name' do 
+          @message.subject.should include(Spree::Config[:site_name])
+        end
       end
-    end  
-  end  
+
+      context 'body includes' do
+        it 'password reset url' do
+          @message.body.raw_source.should include('http://example.com/user/spree_user/password/edit')
+        end
+      end
+    end
+
+    describe 'legacy support for User object' do
+      it 'should send an email' do
+        lambda {
+          Spree::UserMailer.reset_password_instructions(user).deliver
+        }.should change(ActionMailer::Base.deliveries, :size).by(1)
+      end
+    end
+  end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,8 +9,8 @@ describe Spree::User do
   end
 
   it 'should generate the reset password token' do
-    user = build(:user)
-    Spree::UserMailer.should_receive(:reset_password_instructions).with(user).and_return(double(:deliver => true))
+    user = create(:user)
+    Spree::UserMailer.should_receive(:reset_password_instructions).with(user.id).and_return(double(:deliver => true))
     user.send_reset_password_instructions
     user.reset_password_token.should_not be_nil
   end


### PR DESCRIPTION
As a general rule one shouldn't use anything but simple, easily serializable to JSON objects as arguments to Mailer methods.  The reason for this is that in a system that runs mailers in asynchronous workers (e.g. Sidekiq, Resque) the arguments will be serialized to a data store and then unserialized by another process.  So we wish to minimize the size of the data being stored in the data store, keep the serialization as simple as possible, and not use objects that are likely to be mangled during the serialization/de-serialization process.

With that in mind this PR:
1. Changes UserMailer#reset_password_instructions to handle the User object's id as an argument
2. Updates the User model to pass the user id rather than the User object itself
3. Supports the legacy behavior on UserMailer of passing a User object, in case 3rd party users of the framework are using this method directly 
4. Updates the spec to reflect the new common case (passing an id) and adds a spec for the legacy case.
