### PR TITLE
Add authorization logic for Spree::Admin::Orders::CustomerDetailsController

### DIFF
--- a/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
@@ -1,0 +1,19 @@
+require 'spree/admin/orders/customer_details_controller'
+
+if defined?(Spree::Admin::Orders::CustomerDetailsController)
+  Spree::Admin::Orders::CustomerDetailsController.class_eval do
+    before_filter :check_authorization
+
+    private
+      def check_authorization
+        load_order
+        session[:access_token] ||= params[:token]
+
+        resource = @order
+        action = params[:action].to_sym
+        action = :edit if action == :show # show route renders :edit for this controller
+
+        authorize! action, resource, session[:access_token]
+      end
+  end
+end

--- a/spec/features/admin_permissions_spec.rb
+++ b/spec/features/admin_permissions_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe "Admin Permissions" do
-  context "admin is restricted from accessing orders" do
-    before(:each) do
+  context 'orders' do
+    before do
       user = create(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
       Spree::Ability.register_ability(AbilityDecorator)
       visit spree.login_path
@@ -11,15 +11,31 @@ describe "Admin Permissions" do
       click_button "Login"
     end
 
-    it "should not be able to list orders" do
-      visit spree.admin_orders_path
-      page.should have_content("Authorization Failure")
+    context "admin is restricted from accessing orders" do
+      it "should not be able to list orders" do
+        visit spree.admin_orders_path
+        page.should have_content("Authorization Failure")
+      end
+
+      it "should not be able to edit orders" do
+        create(:order, :number => "R123")
+        visit spree.edit_admin_order_path("R123")
+        page.should have_content("Authorization Failure")
+      end
     end
 
-    it "should not be able to edit orders" do
-      create(:order, :number => "R123")
-      visit spree.edit_admin_order_path("R123")
-      page.should have_content("Authorization Failure")
+    context "admin is restricted from accessing an order's customer details" do
+      let(:order) { create(:order_with_totals)}
+
+      it "should not be able to list customer details for an order" do
+        visit spree.admin_order_customer_path(order)
+        page.should have_content("Authorization Failure")
+      end
+
+      it "should not be able to edit an order's customer details" do
+        visit spree.edit_admin_order_customer_path(order)
+        page.should have_content("Authorization Failure")
+      end
     end
   end
 end


### PR DESCRIPTION
While most of the admin controllers have authorization that can be controlled by defining abilities on various resources, this strategy cannot be used on the Spree::Admin::Orders::CustomerDetailsController as this is not a Spree::Admin::ResourceController and doesn't correspond to an actual model.

Instead we should link the authorization behavior for this controller to that of the associated Order, with the additional caveat that the 'show' action on this controller maps to an 'edit' action on the associated Order.

This PR includes the additional controller logic, as well a couple of feature specs.
