### PR TITLE
Add simplecov so we can optionally get coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 spec/dummy
 .sass-cache
+coverage
 Gemfile.lock
 *.swp

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,5 @@
+require 'simplecov'
+
+# .simplecov
+SimpleCov.start 'rails' do
+end

--- a/spec/features/admin/payment_methods_spec.rb
+++ b/spec/features/admin/payment_methods_spec.rb
@@ -11,7 +11,7 @@ describe "Payment methods" do
   # Regression test for #5
   it "can dismiss the banner" do
     Spree::User.any_instance.stub(:dismissed_banner? => false)
-    Spree::PaymentMethod.stub(:production).and_return(payment_methods = [stub])
+    Spree::PaymentMethod.stub(:production).and_return(payment_methods = [double])
     payment_methods.stub(:where).and_return([])
     click_link "Payment Methods"
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # This file is copied to ~/spec when you run 'ruby script/generate rspec'
 # from the project root directory.
 ENV['RAILS_ENV'] ||= 'test'
+if ENV["COVERAGE"]
+  require 'simplecov'
+end
 require File.expand_path('../dummy/config/environment', __FILE__)
 require 'rspec/rails'
 require 'database_cleaner'

--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pg'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
Added simplecov.  To get coverage reports, just set COVERAGE=true before running specs.
1. Added simplecov to the gemspec
2. Added coverage to .gitignore
3. Added a .simplecov file
4. Updated spec_helper.rb to allow optional inclusion of simplecov
5. Fixed a deprecation warning for 'stub'
