### PR TITLE
Allow multiple orders to be accessed in succession in one session

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem 'shoulda-matchers', '~> 1.0.0'
   gem 'capybara', '1.1.3'
   gem 'database_cleaner', '0.9.1'
-  gem 'selenium-webdriver', '2.32.0'
+  gem 'selenium-webdriver', '2.35.1'
   gem 'launchy'
  # gem 'debugger'
 end

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -3,7 +3,7 @@ Spree::OrdersController.class_eval do
 
   private
     def check_authorization
-      session[:access_token] ||= params[:token]
+      session[:access_token] = params[:token] if params[:token]
       order = Spree::Order.find_by_number(params[:id]) || current_order
 
       if order

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -106,6 +106,17 @@ describe Spree::OrdersController do
           spree_get :show, {:id => 'R123', :token => order.token }
           session[:access_token].should == order.token
         end
+
+        context 'when accessing multiple orders in succession' do
+          let(:second_order) { create(:order, :number => 'R456') }
+
+          it 'should store each token as guest_token in session' do
+            spree_get :show, {:id => 'R123', :token => order.token }
+            session[:access_token].should == order.token
+            spree_get :show, {:id => 'R456', :token => second_order.token }
+            session[:access_token].should == second_order.token
+          end
+        end
       end
 
       context 'when no token present' do


### PR DESCRIPTION
Currently the system doesn't allow access to multiple orders via tokens in one session.
