### PR TITLE
Fix user account menu to display translations for order state

### DIFF
--- a/app/views/spree/users/show.html.erb
+++ b/app/views/spree/users/show.html.erb
@@ -27,9 +27,9 @@
         <tr class="<%= cycle('even', 'odd') %>">
           <td class="order-number"><%= link_to order.number, order_url(order) %></td>
           <td class="order-date"><%= l order.completed_at.to_date %></td>
-          <td class="order-status"><%= Spree.t(order.state).titleize %></td>
-          <td class="order-payment-state"><%= Spree.t("payment_states.#{order.payment_state}") if order.payment_state %></td>
-          <td class="order-shipment-state"><%= Spree.t("shipment_states.#{order.shipment_state}") if order.shipment_state %></td>
+          <td class="order-status"><%= Spree.t("order_state.#{order.state}").titleize %></td>
+          <td class="order-payment-state"><%= Spree.t("payment_states.#{order.payment_state}").titleize if order.payment_state %></td>
+          <td class="order-shipment-state"><%= Spree.t("shipment_states.#{order.shipment_state}").titleize if order.shipment_state %></td>
           <td class="order-total"><%= order.display_total %></td>
         </tr>
       <% end %>


### PR DESCRIPTION
When the order state is "canceled" a warning is displayed because there is no `en.spree.canceled` translation. This change brings the order state translation closer inline with the payment and shipment state translations (although perhaps it should be named "order_states" and not "order_state", but that's probably a separate PR).

One other small change is to use `String#titleize` on the 3 statuses so that they are displayed consistently.
