### PR TITLE
use Spree::PermittedAttributes to allow extension

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -39,7 +39,7 @@ class Spree::UsersController < Spree::StoreController
 
   private
     def user_params
-      params.require(:user).permit(Spree::PermittedAttributes.user_attributes)
+      params.require(:user).permit(permitted_user_attributes)
     end
 
     def load_object


### PR DESCRIPTION
Use the class variables in core designed to allow extension to the permitted attributes.
