### PR TITLE
enable strong parameter customization

### DIFF
--- a/app/controllers/spree/user_registrations_controller.rb
+++ b/app/controllers/spree/user_registrations_controller.rb
@@ -9,7 +9,9 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::SSL
-
+  
+  include Spree::Auth::StrongParameters
+  
   ssl_required
   before_filter :check_permissions, :only => [:edit, :update]
   skip_before_filter :require_no_authentication
@@ -66,6 +68,6 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
 
   private
     def spree_user_params
-      params.require(:spree_user).permit(:email, :password, :password_confirmation)
+      params.require(:spree_user).permit(*permitted_spree_user_attributes)
     end
 end

--- a/lib/spree/auth/permitted_attributes.rb
+++ b/lib/spree/auth/permitted_attributes.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Auth
+    module PermittedAttributes
+      ATTRIBUTES = [:spree_user_attributes]
+
+      mattr_reader *ATTRIBUTES
+
+      @@spree_user_attributes = [:email, :password, :password_confirmation]
+    end
+  end
+end

--- a/lib/spree/auth/strong_parameters.rb
+++ b/lib/spree/auth/strong_parameters.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Auth
+    module StrongParameters
+        
+      def permitted_attributes
+        Spree::Auth::PermittedAttributes
+      end
+    
+      delegate *Spree::Auth::PermittedAttributes::ATTRIBUTES,
+                 to: :permitted_attributes,
+                 prefix: :permitted
+    end
+  end
+end

--- a/lib/spree_auth_devise.rb
+++ b/lib/spree_auth_devise.rb
@@ -1,2 +1,4 @@
-require 'spree/auth/devise'
 require 'spree/authentication_helpers'
+require 'spree/auth/devise'
+require 'spree/auth/permitted_attributes'
+require 'spree/auth/strong_parameters'


### PR DESCRIPTION
Following the design pattern recently added to spree 2.1.2  within this commit, https://github.com/spree/spree/commit/64ad1d1df46439a8d1603830140d757c9be9f588, this commit abstracts how strong parameters are defined and used in the user_registrations_controller.

The result is that a spree extension can define a custom array of strong parameters used when a SpreeAuthDevise user is created. This could be done in an initializer. A working example of this,

``` sh
Spree::Auth::PermittedAttributes.spree_user_attributes
# => [:email, :password, :password_confirmation]

Spree::Auth::PermittedAttributes.spree_user_attributes << :my_custom_attribute

Spree::Auth::PermittedAttributes.spree_user_attributes
# => [:email, :password, :password_confirmation, :my_custom_attribute]
```

All credit goes to jhawthorn, and an inspiring gang of IRC advisors Hates, Radar, huoxito, and jstrong
