### PR TITLE
Remove extraneous label tag

### DIFF
--- a/app/views/spree/shared/_login.html.erb
+++ b/app/views/spree/shared/_login.html.erb
@@ -10,10 +10,8 @@
     </p>
   </div>
   <p>
-    <label>
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me, Spree.t(:remember_me) %>
-    </label>
+    <%= f.check_box :remember_me %>
+    <%= f.label :remember_me, Spree.t(:remember_me) %>
   </p>
 
   <p><%= f.submit Spree.t(:login), :class => 'button primary', :tabindex => 3 %></p>


### PR DESCRIPTION
Wrap the checkbox in a label tag _or_ use `<label for=.../>`. Doing both makes the label unclickable in at least some browsers.
