### PR TITLE
Fix order number text

### DIFF
--- a/app/views/spree/users/show.html.erb
+++ b/app/views/spree/users/show.html.erb
@@ -14,7 +14,7 @@
     <table class="order-summary">
       <thead>
       <tr>
-        <th class="order-number"><%= Spree.t(:order_number) %></th>
+        <th class="order-number"><%= I18n.t(:number, :scope => 'activerecord.attributes.spree/order') %></th>
         <th class="order-date"><%= Spree.t(:date) %></th>
         <th class="order-status"><%= Spree.t(:status) %></th>
         <th class="order-payment-state"><%= Spree.t(:payment_state) %></th>


### PR DESCRIPTION
The translation that is currently used expects an argument and
displays 'Order %(number)' without it.  This will now use the same
translation as the admin orders list.
