### PR TITLE
tab through login elements in the order they appear

### DIFF
--- a/lib/views/backend/spree/admin/user_sessions/new.html.erb
+++ b/lib/views/backend/spree/admin/user_sessions/new.html.erb
@@ -18,11 +18,11 @@
         </p>
       </div>
       <p>
-        <%= f.check_box :remember_me %>
+        <%= f.check_box :remember_me, :tabindex => 3 %>
         <%= f.label :remember_me, Spree.t(:remember_me) %>
       </p>
 
-      <p><%= f.submit Spree.t(:login), :class => 'button primary', :tabindex => 3 %></p>
+      <p><%= f.submit Spree.t(:login), :class => 'button primary', :tabindex => 4 %></p>
     <% end %>
     <%= Spree.t(:or) %>
     <%= link_to Spree.t(:forgot_password), spree.recover_password_path %>

--- a/lib/views/frontend/spree/shared/_login.html.erb
+++ b/lib/views/frontend/spree/shared/_login.html.erb
@@ -10,9 +10,9 @@
     </p>
   </div>
   <p>
-    <%= f.check_box :remember_me %>
+    <%= f.check_box :remember_me, :tabindex => 3 %>
     <%= f.label :remember_me, Spree.t(:remember_me) %>
   </p>
 
-  <p><%= f.submit Spree.t(:login), :class => 'button primary', :tabindex => 3 %></p>
+  <p><%= f.submit Spree.t(:login), :class => 'button primary', :tabindex => 4 %></p>
 <% end %>


### PR DESCRIPTION
Tab from email -> password -> remember me -> login

If skipping the "remember me" checkbox was intentional, perhaps we could instead move the checkbox beneath the "login" button?
