### PR TITLE
Uses render instead of deface override in checkout/registration.html.erb template

### DIFF
--- a/app/overrides/auth_user_login_form.rb
+++ b/app/overrides/auth_user_login_form.rb
@@ -1,6 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/checkout/registration",
-                     :name => "auth_user_login_form",
-                     :replace_contents => "[data-hook='registration'] #account, #registration[data-hook] #account",
-                     :template => "spree/user_sessions/new",
-                     :disabled => false,
-                     :original => 'ab20ac9e90baa11b847b30040aef863d2e1af17a')

--- a/app/views/spree/checkout/registration.html.erb
+++ b/app/views/spree/checkout/registration.html.erb
@@ -2,7 +2,7 @@
 <h1><%= Spree.t(:registration) %></h1>
 <div id="registration" data-hook>
   <div id="account" class="columns alpha eight">
-    <!-- TODO: add partial with registration form -->
+    <%= render template: 'spree/user_sessions/new' %>
   </div>
   <% if Spree::Config[:allow_guest_checkout] %>
     <div id="guest_checkout" data-hook class="columns omega eight">


### PR DESCRIPTION
New user session form is now being rendered directly from checkout registration template instead of being called from override
