### PR TITLE
Added gem runtime dependency on coffee-script.

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'devise', '~> 3.2.3'
   s.add_dependency 'devise-encryptable', '0.1.2'
   s.add_dependency 'cancan', '~> 1.6.10'
+  s.add_dependency 'coffee-script', '>= 2.2.0'
 
   s.add_dependency 'json'
   s.add_dependency 'multi_json'


### PR DESCRIPTION
The "require 'coffee_script'" in lib/spree_auth_devise.rb implies that
coffee-script is a runtime dependency, not just a development
dependency. Apps that include Spree but don't explicitly declare
coffee-script as a dependency currently fail when they reach that line.

I don't actually know if '>= 2.2.0' is correct, but I'm guessing it is because
that is the version number used by coffee-rails 4.0.0, which is listed as a 
development dependency.
