### PR TITLE
Redirect to sign_up page if the user is not logged in

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -43,7 +43,7 @@ class Spree::UsersController < Spree::StoreController
       if @user
         authorize! params[:action].to_sym, @user
       else
-        redirect_to spree.signup_path
+        redirect_to spree.login_path
       end
     end
 

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -13,7 +13,7 @@ describe Spree::UsersController do
     it 'should redirect to signup path if user is not found' do
       controller.stub(:spree_current_user => nil)
       spree_put :update, { :user => { :email => 'foobar@example.com' } }
-      response.should redirect_to('/signup')
+      response.should redirect_to('/login')
     end
   end
 


### PR DESCRIPTION
I'm seeing an issue that if the user goes to /account/edit without logged in, it's not redirecting him to sign_up path, it's rendering a blank page
