### PR TITLE
Fix version in 1-3-stable

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_auth_devise'
-  s.version     = '1.0.0'
+  s.version     = '1.3.0'
   s.summary     = 'Provides authentication and authorization services for use with Spree by using Devise and CanCan.'
   s.description = 'Required dependency for Spree'
 


### PR DESCRIPTION
Ran across this while upgrading an old store. The version falls back to 1.0.0 in branch 1-3-stable, after having been 1.2.0 in branch 1-2-stable.
