### PR TITLE
Fix logout links

### DIFF
--- a/lib/views/backend/spree/layouts/admin/_login_nav.html.erb
+++ b/lib/views/backend/spree/layouts/admin/_login_nav.html.erb
@@ -2,7 +2,7 @@
   <ul id="login-nav" class="inline-menu">
     <li data-hook="user-logged-in-as"><%= Spree.t(:logged_in_as) %>: <%= spree_current_user.email %></li>
     <li data-hook="user-account-link"><i class="icon-user"></i><%= link_to Spree.t(:account), spree.edit_user_path(spree_current_user) %></li>
-    <li data-hook="user-logout-link"><i class="icon-signout"></i><%= link_to Spree.t(:logout), spree.destroy_spree_user_session_path %></li>
+    <li data-hook="user-logout-link"><i class="icon-signout"></i><%= link_to Spree.t(:logout), spree.logout_path %></li>
 
     <% if spree.respond_to? :root_path %>
       <li data-hook="store-frontend-link">


### PR DESCRIPTION
## Fixes logout links for 2-2-stable.

`spree.destroy_spree_user_session_path` throws a 404 in 2-2-stable.  This update fixes that issue, relying on the underlying devise routes instead.  Follows the fix from https://github.com/spree/spree_fancy/commit/894a475ff5a9c635a16b65fe01ed9f47575681d7.
