### PR TITLE
Update UserRegistrationsController#Create

### DIFF
--- a/app/controllers/spree/user_registrations_controller.rb
+++ b/app/controllers/spree/user_registrations_controller.rb
@@ -28,7 +28,7 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
       sign_in(:spree_user, @user)
       session[:spree_user_signup] = true
       associate_user
-      sign_in_and_redirect(:spree_user, @user)
+      respond_with resource, location: after_sign_up_path_for(resource)
     else
       clean_up_passwords(resource)
       render :new

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+describe Spree::UserRegistrationsController do
+  before do
+    @request.env["devise.mapping"] = Devise.mappings[:spree_user]
+  end
+  context '#create' do
+    before { controller.stub(:after_sign_up_path_for).and_return(spree.root_path(thing: 7)) }
+    it 'should redirect to after_sign_up_path_for' do
+      spree_post :create, { :spree_user => { :email => 'foobar@example.com', :password => 'foobar123', :password_confirmation => 'foobar123' } }
+      expect(response).to redirect_to spree.root_path(thing: 7)
+    end
+  end
+end

--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_auth_devise'
-  s.version     = '2.1.0'
+  s.version     = '2.1.1'
   s.summary     = 'Provides authentication and authorization services for use with Spree by using Devise and CanCan.'
   s.description = 'Required dependency for Spree'
 


### PR DESCRIPTION
Ensures that the UserRegistrations#create action uses the after_sign_up_path_for method from devise which allows for specifying where to redirect new registrants.
