### PR TITLE
Update edit.html.erb

### DIFF
--- a/app/views/spree/user_passwords/edit.html.erb
+++ b/app/views/spree/user_passwords/edit.html.erb
@@ -1,15 +1,18 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @spree_user } %>
-<h2><%= Spree.t(:change_my_password) %></h2>
 
-<%= form_for @spree_user, :as => :spree_user, :url => spree.update_password_path, :method => :put do |f| %>
-  <p>
-    <%= f.label :password, Spree.t(:password) %><br />
-    <%= f.password_field :password %><br />
-  </p>
-  <p>
-    <%= f.label :password_confirmation, Spree.t(:confirm_password) %><br />
-    <%= f.password_field :password_confirmation %><br />
-  </p>
-  <%= f.hidden_field :reset_password_token %>
-  <%= f.submit Spree.t(:update), :class => 'button primary' %>
-<% end %>
+<div id="change-password">
+  <h6><%= Spree.t(:change_my_password) %></h6>
+  
+  <%= form_for @spree_user, :as => :spree_user, :url => spree.update_password_path, :method => :put do |f| %>
+    <p>
+      <%= f.label :password, Spree.t(:password) %><br />
+      <%= f.password_field :password %><br />
+    </p>
+    <p>
+      <%= f.label :password_confirmation, Spree.t(:confirm_password) %><br />
+      <%= f.password_field :password_confirmation %><br />
+    </p>
+    <%= f.hidden_field :reset_password_token %>
+    <%= f.submit Spree.t(:update), :class => 'button primary' %>
+  <% end %>
+</div>


### PR DESCRIPTION
I don't have an aesthetic opinion one way or another, but for consistency's sake -- e.g., with https://github.com/spree/spree_auth_devise/blob/2-0-stable/app/views/spree/user_passwords/new.html.erb as well as with the [login](https://github.com/spree/spree_auth_devise/blob/2-0-stable/app/views/spree/user_sessions/new.html.erb) and [signup](https://github.com/spree/spree_auth_devise/blob/2-0-stable/app/views/spree/user_registrations/new.html.erb) views, I reckon we should wrap the relevant lines in some kind of `div` and use `h6` rather than `h2`.

(Although in my personal opinion we should use `h2` for _all_ of these four, but I'm happy to go with the convention and use `h6` if three of them already do.)
