### PR TITLE
Add autofocus to login form

### DIFF
--- a/app/views/spree/shared/_login.html.erb
+++ b/app/views/spree/shared/_login.html.erb
@@ -2,7 +2,7 @@
   <div id="password-credentials">
     <p>
       <%= f.label :email, Spree.t(:email) %><br />
-      <%= f.email_field :email, :class => 'title', :tabindex => 1 %>
+      <%= f.email_field :email, :class => 'title', :tabindex => 1, autofocus: true %>
     </p>
     <p>
       <%= f.label :password, Spree.t(:password) %><br />


### PR DESCRIPTION
Springing from the discussion in https://github.com/spree/spree/issues/4715, this change allows the HTML5 `autofocus` attribute to put the cursor into the email field when displaying the login screen, which removes one step from the user login process.
