### PR TITLE
Change admin logout path to use the admin namespaced logout path

### DIFF
--- a/lib/views/backend/spree/layouts/admin/_login_nav.html.erb
+++ b/lib/views/backend/spree/layouts/admin/_login_nav.html.erb
@@ -2,7 +2,7 @@
   <ul id="login-nav" class="inline-menu">
     <li data-hook="user-logged-in-as"><%= Spree.t(:logged_in_as) %>: <%= spree_current_user.email %></li>
     <li data-hook="user-account-link" class='fa fa-user'><%= link_to Spree.t(:account), spree.edit_user_path(spree_current_user) %></li>
-    <li data-hook="user-logout-link" class='fa fa-sign-out'><%= link_to Spree.t(:logout), spree.logout_path %></li>
+    <li data-hook="user-logout-link" class='fa fa-sign-out'><%= link_to Spree.t(:logout), spree.admin_logout_path %></li>
 
     <% if spree.respond_to? :root_path %>
       <li data-hook="store-frontend-link" class='fa fa-external-link'>


### PR DESCRIPTION
tests seem to be failing on this branch, but those are due to the failures on master it appears.

this change will help us (and other people) who don't have /users routing to spree (e.g. a separate frontend driven through the api), so that admin users can logout.
