### PR TITLE
Fix view bug with "Order #"

### DIFF
--- a/app/views/spree/users/show.html.erb
+++ b/app/views/spree/users/show.html.erb
@@ -14,7 +14,7 @@
     <table class="order-summary">
       <thead>
       <tr>
-        <th class="order-number"><%= Spree.t(:order_number) %></th>
+        <th class="order-number"><%= Spree.t(:order_num) %></th>
         <th class="order-date"><%= Spree.t(:order_date) %></th>
         <th class="order-status"><%= Spree.t(:status) %></th>
         <th class="order-payment-state"><%= Spree.t(:payment_state) %></th>


### PR DESCRIPTION
As discussed in https://github.com/spree/spree/issues/4792, `Spree.t(:order_number)` is actually meant to take a `:number` variable, but to generate the string 'Order #' (with the hash sign) we use `Spree.t(:order_num)` instead.
