### PR TITLE
mandate spacing in user_sessions/new

### DIFF
--- a/app/views/spree/user_sessions/new.html.erb
+++ b/app/views/spree/user_sessions/new.html.erb
@@ -7,9 +7,7 @@
   <h6><%= Spree.t(:login_as_existing) %></h6>
   <div data-hook="login">
     <%= render :partial => 'spree/shared/login' %>
-    <%= Spree.t(:or) %>
-    <%= link_to Spree.t(:create_a_new_account), spree.signup_path %> |
-    <%= link_to Spree.t(:forgot_password), spree.recover_password_path %>
+    <%= Spree.t(:or) %>&nbsp;<%= link_to Spree.t(:create_a_new_account), spree.signup_path %> | <%= link_to Spree.t(:forgot_password), spree.recover_password_path %>
   </div>
 </div>
 <div data-hook="login_extras"></div>


### PR DESCRIPTION
Spacing would sometimes be inconsistent in this line, with the newline rendering at times as a space, and at times not. A nonbreaking space will resolve this.
