### PR TITLE
2-3-stable branch should be dependent on spree 2-3-stable.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: '2-3-stable'
 
 gemspec


### PR DESCRIPTION
Now `gem 'spree', github: 'spree/spree', branch: 'master'` dependent on spree_backend 2.4.0.beta. 
As a result it cannot find compatible spree_backend.

```
Resolving dependencies...
Bundler could not find compatible versions for gem "spree_backend":
  In Gemfile:
    spree_backend (~> 2.3.0) ruby

    spree (>= 0) ruby depends on
      spree_backend (2.4.0.beta)
```
