### PR TITLE
Provide method to add actions which don't call load_order

### DIFF
--- a/lib/controllers/backend/spree/admin/admin_orders_controller_decorator.rb
+++ b/lib/controllers/backend/spree/admin/admin_orders_controller_decorator.rb
@@ -5,7 +5,7 @@ Spree::Admin::OrdersController.class_eval do
     def not_load_order_action
       [:index, :new]
     end
-    
+
     def check_authorization
       action = params[:action].to_sym
       if not_load_order_action.include?(action)

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+feature 'Admin orders' do
+  background do
+    sign_in_as! create(:admin_user)
+  end
+
+  # regression #203
+  scenario 'can lists orders' do
+    expect { visit spree.admin_orders_path }.not_to raise_error
+  end
+
+  # regression #203
+  scenario 'can new orders' do
+    expect { visit spree.new_admin_order_path }.not_to raise_error
+  end
+
+  # regression #203
+  scenario 'can not edit orders' do
+    expect { visit spree.edit_admin_order_path('nodata') }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  # regression #203
+  scenario 'can edit orders' do
+    create(:order, number: 'R123')
+    visit spree.edit_admin_order_path('R123')
+    expect(page).not_to have_text 'Authorization Failure'
+  end
+
+end

--- a/spec/features/admin_permissions_spec.rb
+++ b/spec/features/admin_permissions_spec.rb
@@ -23,6 +23,11 @@ feature 'Admin Permissions' do
         visit spree.edit_admin_order_path('R123')
         expect(page).to have_text 'Authorization Failure'
       end
+
+      scenario 'can not new orders' do
+        visit spree.new_admin_order_path
+        expect(page).to have_text 'Authorization Failure'
+      end
     end
 
     context "admin is restricted from accessing an order's customer details" do


### PR DESCRIPTION
Some action cannot call load_order. (e, g. exporting all order's data)

This change provide the way to add those action without overriding `check_authorization`.
