### PR TITLE
Use the Spree::Store.current.url when sending the password reset link

### DIFF
--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -1,7 +1,7 @@
 module Spree
   class UserMailer < BaseMailer
     def reset_password_instructions(user, token, *args)
-      @edit_password_reset_url = spree.edit_spree_user_password_url(:reset_password_token => token)
+      @edit_password_reset_url = spree.edit_spree_user_password_url(:reset_password_token => token, :host => Spree::Store.current.url)
 
       mail to: user.email, from: from_address, subject: Spree::Store.current.name + ' ' + I18n.t(:subject, :scope => [:devise, :mailer, :reset_password_instructions])
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,7 +5,6 @@ describe Spree::UserMailer do
   let(:user) { create(:user) }
 
   before do
-    ActionMailer::Base.default_url_options[:host] = 'http://example.com'
     user = create(:user)
     Spree::UserMailer.reset_password_instructions(user, 'token goes here').deliver
     @message = ActionMailer::Base.deliveries.last
@@ -32,7 +31,7 @@ describe Spree::UserMailer do
 
       context 'body includes' do
         it 'password reset url' do
-          expect(@message.body.raw_source).to include 'http://example.com/user/spree_user/password/edit'
+          expect(@message.body.raw_source).to include "http://#{store.url}/user/spree_user/password/edit"
         end
       end
     end


### PR DESCRIPTION
See issue https://github.com/spree/spree_auth_devise/issues/216
