### PR TITLE
Fix user session redirect.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
     user_passwords:
       spree_user:
         cannot_be_blank: Your password cannot be blank.
+        no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
         send_instructions: You will receive an email with instructions about how to reset your password in a few minutes.
         updated: Your password was changed successfully. You are now signed in.
     user_registrations:

--- a/lib/controllers/frontend/spree/user_passwords_controller.rb
+++ b/lib/controllers/frontend/spree/user_passwords_controller.rb
@@ -45,4 +45,9 @@ class Spree::UserPasswordsController < Devise::PasswordsController
     end
   end
 
+  protected
+
+  def new_session_path(resource_name)
+    spree.send("new_#{resource_name}_session_path")
+  end
 end

--- a/spec/controllers/spree/user_passwords_controller_spec.rb
+++ b/spec/controllers/spree/user_passwords_controller_spec.rb
@@ -4,6 +4,32 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
 
   before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] }
 
+  describe 'GET edit' do
+    context 'when the user token has not been specified' do
+      it 'redirects to the new session path' do
+        spree_get :edit
+        expect(response).to redirect_to(
+          'http://test.host/user/spree_user/sign_in'
+        )
+      end
+
+      it 'flashes an error' do
+        spree_get :edit
+        expect(flash[:alert]).to include(
+          "You can't access this page without coming from a password reset " +
+          'email'
+        )
+      end
+    end
+
+    context 'when the user token has been specified' do
+      it 'does something' do
+        spree_get :edit, reset_password_token: token
+        expect(response.code).to eq('200')
+      end
+    end
+  end
+
   context '#update' do
     context 'when updating password with blank password' do
       it 'shows error flash message, sets spree_user with token and re-displays password edit form' do


### PR DESCRIPTION
This currently redirects people to main app routes rather than Spree
routes.

This would lead to the following 500 error:

```
NoMethodError: undefined method `new_spree_user_session_path' for #<ActionDispatch::Routing::RoutesProxy:0x0000000c9a5e00>
```

As `new_spree_user_session_path` is not defined in the main app routes.

This likely occurs in other controllers as well.
