### PR TITLE
add already signed in translation for en

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
     user_sessions:
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
+      already_signed_in: Already signed in.
   errors:
     messages:
       already_confirmed: was already confirmed


### PR DESCRIPTION
In an application I received this failure from RSpec:

``` ruby
Failure/Error: expect(page).to have_text 'Signed out successfully.'
       expected to find text "Signed out successfully." in "Signup Login Cart: (Empty) translation missing: en.devise.user_sessions.spree_user.already_signed_out"
```

This should help fix that.
