### PR TITLE
only load order for specific actions

### DIFF
--- a/lib/controllers/backend/spree/admin/admin_orders_controller_decorator.rb
+++ b/lib/controllers/backend/spree/admin/admin_orders_controller_decorator.rb
@@ -2,19 +2,19 @@ Spree::Admin::OrdersController.class_eval do
   before_filter :check_authorization
 
   private
-    def not_load_order_action
-      [:index, :new]
+    def load_order_action
+      [:edit, :update, :cancel, :resume, :approve, :resend, :open_adjustments, :close_adjustments, :cart]
     end
-
+  
     def check_authorization
       action = params[:action].to_sym
-      if not_load_order_action.include?(action)
-        authorize! :index, Spree::Order
-      else
+      if load_order_action.include?(action)
         load_order
         session[:access_token] ||= params[:token]
         resource = @order || Spree::Order.new
         authorize! action, resource, session[:access_token]
+      else
+        authorize! :index, Spree::Order
       end
     end
 end


### PR DESCRIPTION
according to https://github.com/spree/spree/blob/master/backend/app/controllers/spree/admin/orders_controller.rb#5

This validation should be reversed since load_order should be call for only listed actions.
