### PR TITLE
depend on spree 2.4.0, without the beta version level

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '~> 2.4.0.beta'
+  spree_version = '~> 2.4.0'
 
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'devise', '~> 3.2.3'


### PR DESCRIPTION
The `~> 2.4.0.beta` dependency caused conflicts with stable versions of spree and `2.4.0.rcX` dependencies in other extensions. So it's just `~> 2.4.0` dependency now which works like charm with spree 2.4.x.
