### PR TITLE
[2-4-stable] Remove cancan dependency for Spree 2.4.x

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'devise', '~> 3.2.3'
   s.add_dependency 'devise-encryptable', '0.1.2'
-  s.add_dependency 'cancan', '~> 1.6.10'
 
   s.add_dependency 'json'
   s.add_dependency 'multi_json'


### PR DESCRIPTION
spree_core 2.4.0+ depends on cancancan, so spree_auth_devise should not depend on the conflicting cancan gem.