### PR TITLE
Revert "spec to allow new users to be created with same email as deleted users"

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -8,7 +8,6 @@ module Spree
     devise :confirmable if Spree::Auth::Config[:confirmable]
 
     acts_as_paranoid
-    after_destroy :scramble_email_and_password
 
     has_many :orders
 
@@ -37,14 +36,6 @@ module Spree
       def set_login
         # for now force login to be same as email, eventually we will make this configurable, etc.
         self.login ||= self.email if self.email
-      end
-
-      def scramble_email_and_password
-        self.email = SecureRandom.uuid + "@example.net"
-        self.login = self.email
-        self.password = SecureRandom.hex(8)
-        self.password_confirmation = self.password
-        self.save
       end
   end
 end


### PR DESCRIPTION
This reverts commit c53aec17c2b18596a83c15b5abc4f3042c324236.

Conflicts:
    app/models/spree/user.rb
    spec/models/user_spec.rb

Per conversation in #223 

This will allow further work to fix the spec by filtering validations properly.
