### PR TITLE
Login page polishing

### DIFF
--- a/lib/views/backend/spree/admin/user_sessions/new.html.erb
+++ b/lib/views/backend/spree/admin/user_sessions/new.html.erb
@@ -2,27 +2,37 @@
   <div class="alert alert-danger"><%= flash[:alert] %></div>
 <% end %>
 
-<div data-hook="login">
-  <%= form_for Spree::User.new, :as => :spree_user, :url => spree.admin_create_new_session_path do |f| %>
-    <div id="password-credentials">
-      <%= f.label :email, Spree.t(:email), class: "sr-only" %>
-      <%= f.email_field :email, class: 'form-control', tabindex: 1, placeholder: Spree.t(:email) %>
-      <%= f.label :password, Spree.t(:password), class: "sr-only" %>
-      <%= f.password_field :password, :class => 'form-control', :tabindex => 2, placeholder: Spree.t(:password) %>
-    </div>
-    <div class="checkbox form-group">
-      <%= f.label :remember_me do %>
-        <%= f.check_box :remember_me, :tabindex => 3 %>
-        <%= Spree.t(:remember_me) %>
-      <% end %>
-    </div>
-    <div class="form-group">
-      <%= f.submit Spree.t(:login), :class => 'btn btn-primary btn-block', :tabindex => 4 %>
-    </div>
-  <% end %>
-  <p>
-    <%= Spree.t(:or) %> <%= link_to Spree.t(:forgot_password), spree.recover_password_path %>
-  </p>
+<div data-hook="login" class="panel">
+  <div class="panel-body">
+    <%= form_for Spree::User.new, :as => :spree_user, :url => spree.admin_create_new_session_path do |f| %>
+      <div id="password-credentials">
+        <div class="form-group text-center">
+          <%= f.label :email, Spree.t(:email) %>
+          <%= f.email_field :email, class: 'form-control', tabindex: 1, placeholder: Spree.t(:email) %>  
+        </div>
+        <div class="form-group text-center">
+          <%= f.label :password, Spree.t(:password) %>
+          <%= f.password_field :password, :class => 'form-control', :tabindex => 2, placeholder: Spree.t(:password) %>
+        </div>
+      </div>
+      <div class="checkbox form-group">
+        <div class="row">
+          <div class="col-md-6">
+            <%= f.label :remember_me do %>
+              <%= f.check_box :remember_me, :tabindex => 3 %>
+              <%= Spree.t(:remember_me) %>
+            <% end %>  
+          </div>
+          <div class="col-md-6 text-right">
+            <%= link_to Spree.t(:forgot_password), spree.recover_password_path %>
+          </div>  
+        </div>      
+      </div>
+      <div class="form-group">
+        <%= f.submit Spree.t(:login), :class => 'btn btn-primary btn-block', :tabindex => 4 %>
+      </div>
+    <% end %>
+  </div>
 </div>
 
 <div data-hook="login_extras"></div>


### PR DESCRIPTION
Bring back labels. Position *Forgot Password?* right to *Remember me*. Add some space around login form.