### PR TITLE
cleanup helpers

### DIFF
--- a/lib/controllers/frontend/spree/user_confirmations_controller.rb
+++ b/lib/controllers/frontend/spree/user_confirmations_controller.rb
@@ -1,9 +1,5 @@
 class Spree::UserConfirmationsController < Devise::ConfirmationsController
-  helper 'spree/base', 'spree/store'
-
-  if Spree::Auth::Engine.dash_available?
-    helper 'spree/analytics'
-  end
+  helper 'spree/base'
 
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common

--- a/lib/controllers/frontend/spree/user_passwords_controller.rb
+++ b/lib/controllers/frontend/spree/user_passwords_controller.rb
@@ -1,9 +1,5 @@
 class Spree::UserPasswordsController < Devise::PasswordsController
-  helper 'spree/base', 'spree/store'
-
-  if Spree::Auth::Engine.dash_available?
-    helper 'spree/analytics'
-  end
+  helper 'spree/base'
 
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -1,9 +1,5 @@
 class Spree::UserRegistrationsController < Devise::RegistrationsController
-  helper 'spree/base', 'spree/store'
-
-  if Spree::Auth::Engine.dash_available?
-    helper 'spree/analytics'
-  end
+  helper 'spree/base'
 
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -1,8 +1,5 @@
 class Spree::UserSessionsController < Devise::SessionsController
-  helper 'spree/base', 'spree/store'
-  if Spree::Auth::Engine.dash_available?
-    helper 'spree/analytics'
-  end
+  helper 'spree/base'
 
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common


### PR DESCRIPTION
In Spree 3, the store helper was removed. This PR removes the calls to the `spree/store` helper.

Also, there is an if statement for the analytics helper. I don't think Spree has a analytics dash anymore.
