### PR TITLE
Redirect to the order success page without the token

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -37,11 +37,4 @@ Spree::CheckoutController.class_eval do
       store_location
       redirect_to spree.checkout_registration_path
     end
-
-    # Overrides the equivalent method defined in Spree::Core.  This variation of the method will ensure that users
-    # are redirected to the tokenized order url unless authenticated as a registered user.
-    def completion_route
-      return spree.order_path(@order) if spree_current_user
-      spree.token_order_path(@order, @order.guest_token)
-    end
 end

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         it 'redirects to the tokenized order view' do
           request.cookie_jar.signed[:guest_token] = 'ABC'
           spree_post :update, { state: 'confirm' }
-          expect(response).to redirect_to spree.token_order_path(order, 'ABC')
+          expect(response).to redirect_to spree.order_path(order)
           expect(flash.notice).to eq Spree.t(:order_processed_successfully)
         end
       end


### PR DESCRIPTION
Doing it with the token potentially exposes customers' sensitive details if someone gets a hold of the URL.