### PR TITLE
only load up checkout and users if frontend is available

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,41 +1,43 @@
-require 'spree/core/validators/email'
+if defined? Spree::Frontend
+  require 'spree/core/validators/email'
 
-Spree::CheckoutController.class_eval do
-  before_filter :check_authorization
-  before_filter :check_registration, :except => [:registration, :update_registration]
+  Spree::CheckoutController.class_eval do
+    before_filter :check_authorization
+    before_filter :check_registration, :except => [:registration, :update_registration]
 
-  def registration
-    @user = Spree::User.new
-  end
-
-  def update_registration
-    if params[:order][:email] =~ Devise.email_regexp && current_order.update_attribute(:email, params[:order][:email])
-      redirect_to spree.checkout_path
-    else
-      flash[:registration_error] = t(:email_is_invalid, :scope => [:errors, :messages])
+    def registration
       @user = Spree::User.new
-      render 'registration'
     end
+
+    def update_registration
+      if params[:order][:email] =~ Devise.email_regexp && current_order.update_attribute(:email, params[:order][:email])
+        redirect_to spree.checkout_path
+      else
+        flash[:registration_error] = t(:email_is_invalid, :scope => [:errors, :messages])
+        @user = Spree::User.new
+        render 'registration'
+      end
+    end
+
+    private
+      def order_params
+        params[:order] ? params.require(:order).permit(:email) : {}
+      end
+
+      def skip_state_validation?
+        %w(registration update_registration).include?(params[:action])
+      end
+
+      def check_authorization
+        authorize!(:edit, current_order, cookies.signed[:guest_token])
+      end
+
+      # Introduces a registration step whenever the +registration_step+ preference is true.
+      def check_registration
+        return unless Spree::Auth::Config[:registration_step]
+        return if spree_current_user or current_order.email
+        store_location
+        redirect_to spree.checkout_registration_path
+      end
   end
-
-  private
-    def order_params
-      params[:order] ? params.require(:order).permit(:email) : {}
-    end
-
-    def skip_state_validation?
-      %w(registration update_registration).include?(params[:action])
-    end
-
-    def check_authorization
-      authorize!(:edit, current_order, cookies.signed[:guest_token])
-    end
-
-    # Introduces a registration step whenever the +registration_step+ preference is true.
-    def check_registration
-      return unless Spree::Auth::Config[:registration_step]
-      return if spree_current_user or current_order.email
-      store_location
-      redirect_to spree.checkout_registration_path
-    end
 end

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,41 +1,42 @@
-defined?(Spree::CheckoutController) && Spree::CheckoutController.class_eval do
+if defined? Spree::CheckoutController
   require 'spree/core/validators/email'
+  Spree::CheckoutController.class_eval do
+    before_filter :check_authorization
+    before_filter :check_registration, :except => [:registration, :update_registration]
 
-  before_filter :check_authorization
-  before_filter :check_registration, :except => [:registration, :update_registration]
-
-  def registration
-    @user = Spree::User.new
-  end
-
-  def update_registration
-    if params[:order][:email] =~ Devise.email_regexp && current_order.update_attribute(:email, params[:order][:email])
-      redirect_to spree.checkout_path
-    else
-      flash[:registration_error] = t(:email_is_invalid, :scope => [:errors, :messages])
+    def registration
       @user = Spree::User.new
-      render 'registration'
     end
+
+    def update_registration
+      if params[:order][:email] =~ Devise.email_regexp && current_order.update_attribute(:email, params[:order][:email])
+        redirect_to spree.checkout_path
+      else
+        flash[:registration_error] = t(:email_is_invalid, :scope => [:errors, :messages])
+        @user = Spree::User.new
+        render 'registration'
+      end
+    end
+
+    private
+      def order_params
+        params[:order] ? params.require(:order).permit(:email) : {}
+      end
+
+      def skip_state_validation?
+        %w(registration update_registration).include?(params[:action])
+      end
+
+      def check_authorization
+        authorize!(:edit, current_order, cookies.signed[:guest_token])
+      end
+
+      # Introduces a registration step whenever the +registration_step+ preference is true.
+      def check_registration
+        return unless Spree::Auth::Config[:registration_step]
+        return if spree_current_user or current_order.email
+        store_location
+        redirect_to spree.checkout_registration_path
+      end
   end
-
-  private
-    def order_params
-      params[:order] ? params.require(:order).permit(:email) : {}
-    end
-
-    def skip_state_validation?
-      %w(registration update_registration).include?(params[:action])
-    end
-
-    def check_authorization
-      authorize!(:edit, current_order, cookies.signed[:guest_token])
-    end
-
-    # Introduces a registration step whenever the +registration_step+ preference is true.
-    def check_registration
-      return unless Spree::Auth::Config[:registration_step]
-      return if spree_current_user or current_order.email
-      store_location
-      redirect_to spree.checkout_registration_path
-    end
 end

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,5 +1,6 @@
-require 'spree/core/validators/email'
-Spree::CheckoutController.class_eval do
+defined?(Spree::CheckoutController) && Spree::CheckoutController.class_eval do
+  require 'spree/core/validators/email'
+
   before_filter :check_authorization
   before_filter :check_registration, :except => [:registration, :update_registration]
 

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,47 +1,41 @@
-if defined? Spree::CheckoutController
-  require 'spree/core/validators/email'
+require 'spree/core/validators/email'
 
-  Spree::CheckoutController.class_eval do
-    before_filter :check_authorization
-    before_filter :check_registration, :except => [:registration, :update_registration]
+Spree::CheckoutController.class_eval do
+  before_filter :check_authorization
+  before_filter :check_registration, :except => [:registration, :update_registration]
 
-    def registration
-      @user = Spree::User.new
-    end
-
-    def update_registration
-      if params[:order][:email] =~ Devise.email_regexp && current_order.update_attribute(:email, params[:order][:email])
-        redirect_to spree.checkout_path
-      else
-        flash[:registration_error] = t(:email_is_invalid, :scope => [:errors, :messages])
-        @user = Spree::User.new
-        render 'registration'
-      end
-    end
-
-    private
-      def order_params
-        params[:order] ? params.require(:order).permit(:email) : {}
-      end
-
-      def skip_state_validation?
-        %w(registration update_registration).include?(params[:action])
-      end
-
-      def check_authorization
-        authorize!(:edit, current_order, cookies.signed[:guest_token])
-      end
-
-      # Introduces a registration step whenever the +registration_step+ preference is true.
-      def check_registration
-        return unless Spree::Auth::Config[:registration_step]
-        return if spree_current_user or current_order.email
-        store_location
-        redirect_to spree.checkout_registration_path
-      end
+  def registration
+    @user = Spree::User.new
   end
-elsif Rails.env.test?
-  puts '-----------------------------------------'
-  puts "Spree::CheckoutController is not defined."
-  puts '-----------------------------------------'
+
+  def update_registration
+    if params[:order][:email] =~ Devise.email_regexp && current_order.update_attribute(:email, params[:order][:email])
+      redirect_to spree.checkout_path
+    else
+      flash[:registration_error] = t(:email_is_invalid, :scope => [:errors, :messages])
+      @user = Spree::User.new
+      render 'registration'
+    end
+  end
+
+  private
+    def order_params
+      params[:order] ? params.require(:order).permit(:email) : {}
+    end
+
+    def skip_state_validation?
+      %w(registration update_registration).include?(params[:action])
+    end
+
+    def check_authorization
+      authorize!(:edit, current_order, cookies.signed[:guest_token])
+    end
+
+    # Introduces a registration step whenever the +registration_step+ preference is true.
+    def check_registration
+      return unless Spree::Auth::Config[:registration_step]
+      return if spree_current_user or current_order.email
+      store_location
+      redirect_to spree.checkout_registration_path
+    end
 end

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,5 +1,6 @@
 if defined? Spree::CheckoutController
   require 'spree/core/validators/email'
+
   Spree::CheckoutController.class_eval do
     before_filter :check_authorization
     before_filter :check_registration, :except => [:registration, :update_registration]
@@ -39,4 +40,8 @@ if defined? Spree::CheckoutController
         redirect_to spree.checkout_registration_path
       end
   end
+elsif Rails.env.test?
+  puts '-----------------------------------------'
+  puts "Spree::CheckoutController is not defined."
+  puts '-----------------------------------------'
 end

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -51,4 +51,8 @@ if defined? Spree::StoreController
         Spree.t(:my_account)
       end
   end
+elsif Rails.env.test?
+  puts '--------------------------------------'
+  puts "Spree::StoreController is not defined."
+  puts '--------------------------------------'
 end

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -1,56 +1,54 @@
-defined?(Spree::StoreController) && class Spree::UsersController < Spree::StoreController
-  skip_before_filter :set_current_order, :only => :show
-  prepend_before_filter :load_object, :only => [:show, :edit, :update]
-  prepend_before_filter :authorize_actions, :only => :new
+if defined? Spree::StoreController
+  class Spree::UsersController < Spree::StoreController
+    skip_before_filter :set_current_order, :only => :show
+    prepend_before_filter :load_object, :only => [:show, :edit, :update]
+    prepend_before_filter :authorize_actions, :only => :new
 
-  include Spree::Core::ControllerHelpers
+    include Spree::Core::ControllerHelpers
 
-  def show
-    @orders = @user.orders.complete.order('completed_at desc')
-  end
+    def show
+      @orders = @user.orders.complete.order('completed_at desc')
+    end
 
-  def create
-    @user = Spree::User.new(user_params)
-    if @user.save
+    def create
+      @user = Spree::User.new(user_params)
+      if @user.save
+        session[:guest_token] = nil if current_order
+        redirect_back_or_default(root_url)
+      else
+        render :new
+      end
+    end
 
-      if current_order
-        session[:guest_token] = nil
+    def update
+      if @user.update_attributes(user_params)
+        if params[:user][:password].present?
+          # this logic needed b/c devise wants to log us out after password changes
+          user = Spree::User.reset_password_by_token(params[:user])
+          sign_in(@user, :event => :authentication, :bypass => !Spree::Auth::Config[:signout_after_password_change])
+        end
+        redirect_to spree.account_url, :notice => Spree.t(:account_updated)
+      else
+        render :edit
+      end
+    end
+
+    private
+      def user_params
+        params.require(:user).permit(Spree::PermittedAttributes.user_attributes)
       end
 
-      redirect_back_or_default(root_url)
-    else
-      render :new
-    end
-  end
-
-  def update
-    if @user.update_attributes(user_params)
-      if params[:user][:password].present?
-        # this logic needed b/c devise wants to log us out after password changes
-        user = Spree::User.reset_password_by_token(params[:user])
-        sign_in(@user, :event => :authentication, :bypass => !Spree::Auth::Config[:signout_after_password_change])
+      def load_object
+        @user ||= spree_current_user
+        authorize! params[:action].to_sym, @user
       end
-      redirect_to spree.account_url, :notice => Spree.t(:account_updated)
-    else
-      render :edit
-    end
+
+      def authorize_actions
+        authorize! params[:action].to_sym, Spree::User.new
+      end
+
+      def accurate_title
+        Spree.t(:my_account)
+      end
   end
-
-  private
-    def user_params
-      params.require(:user).permit(Spree::PermittedAttributes.user_attributes)
-    end
-
-    def load_object
-      @user ||= spree_current_user
-      authorize! params[:action].to_sym, @user
-    end
-
-    def authorize_actions
-      authorize! params[:action].to_sym, Spree::User.new
-    end
-
-    def accurate_title
-      Spree.t(:my_account)
-    end
 end

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -1,4 +1,4 @@
-class Spree::UsersController < Spree::StoreController
+defined?(Spree::StoreController) && class Spree::UsersController < Spree::StoreController
   skip_before_filter :set_current_order, :only => :show
   prepend_before_filter :load_object, :only => [:show, :edit, :update]
   prepend_before_filter :authorize_actions, :only => :new

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -51,8 +51,4 @@ if defined? Spree::StoreController
         Spree.t(:my_account)
       end
   end
-elsif Rails.env.test?
-  puts '--------------------------------------'
-  puts "Spree::StoreController is not defined."
-  puts '--------------------------------------'
 end

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -1,4 +1,4 @@
-if defined? Spree::StoreController
+if defined? Spree::Frontend
   class Spree::UsersController < Spree::StoreController
     skip_before_filter :set_current_order, :only => :show
     prepend_before_filter :load_object, :only => [:show, :edit, :update]

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe Spree::CheckoutController, type: :controller do
-
   let(:order) { create(:order_with_totals, email: nil, user: nil) }
   let(:user)  { build(:user, spree_api_key: 'fake') }
   let(:token) { 'some_token' }


### PR DESCRIPTION
After experimenting with spree_auth_devise without the spree_frontend, this change will make it possible for developers to have spree_auth_devise controllers without having to add the spree_frontend gem to their dependencies.

If you're like me, wanting the controllers of the spree_auth_devise frontend, but not have the whole spree_frontend, then you can add this to your `config/application.rb`:

```ruby
Spree::Auth::Engine.paths["app/controllers"] << "lib/controllers/frontend"
```
