### PR TITLE
Remove <br> tags after frontend form labels 

### DIFF
--- a/lib/views/frontend/spree/shared/_login.html.erb
+++ b/lib/views/frontend/spree/shared/_login.html.erb
@@ -1,11 +1,11 @@
 <%= form_for Spree::User.new, :as => :spree_user, :url => spree.create_new_session_path do |f| %>
   <div id="password-credentials">
     <p>
-      <%= f.label :email, Spree.t(:email) %><br />
+      <%= f.label :email, Spree.t(:email) %>
       <%= f.email_field :email, :class => 'form-control', :tabindex => 1, autofocus: true %>
     </p>
     <p>
-      <%= f.label :password, Spree.t(:password) %><br />
+      <%= f.label :password, Spree.t(:password) %>
       <%= f.password_field :password, :class => 'form-control', :tabindex => 2 %>
     </p>
   </div>

--- a/lib/views/frontend/spree/user_passwords/edit.html.erb
+++ b/lib/views/frontend/spree/user_passwords/edit.html.erb
@@ -7,12 +7,12 @@
     <div class="panel-body">
       <%= form_for @spree_user, :as => :spree_user, :url => spree.update_password_path, :method => :put do |f| %>
         <p>
-          <%= f.label :password, Spree.t(:password) %><br />
-          <%= f.password_field :password, :class => "form-control" %><br />
+          <%= f.label :password, Spree.t(:password) %>
+          <%= f.password_field :password, :class => "form-control" %>
         </p>
         <p>
-          <%= f.label :password_confirmation, Spree.t(:confirm_password) %><br />
-          <%= f.password_field :password_confirmation, :class => "form-control" %><br />
+          <%= f.label :password_confirmation, Spree.t(:confirm_password) %>
+          <%= f.password_field :password_confirmation, :class => "form-control" %>
         </p>
         <%= f.hidden_field :reset_password_token %>
         <%= f.submit Spree.t(:update), :class => 'btn btn-lg btn-success btn-block' %>

--- a/lib/views/frontend/spree/user_passwords/new.html.erb
+++ b/lib/views/frontend/spree/user_passwords/new.html.erb
@@ -9,7 +9,7 @@
 
       <%= form_for Spree::User.new, :as => :spree_user, :url => spree.reset_password_path do |f| %>
         <p>
-          <%= f.label :email, Spree.t(:email) %><br />
+          <%= f.label :email, Spree.t(:email) %>
           <%= f.email_field :email, :class => "form-control" %>
         </p>
         <p>


### PR DESCRIPTION
This makes spree_auth_devise frontend form HTML consistent with changes recently made to the frontend form view in Spree's master branch. See spree/spree#6232 and spree/spree#6237 for more info.