### PR TITLE
Updated translation to :create_a_new_account in /checkout/registration

### DIFF
--- a/lib/views/frontend/spree/checkout/_new_user.html.erb
+++ b/lib/views/frontend/spree/checkout/_new_user.html.erb
@@ -1,7 +1,7 @@
 <div class="col-md-6">
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title"><%= Spree.t(:create_new_account) %></h3>
+      <h3 class="panel-title"><%= Spree.t(:create_a_new_account) %></h3>
     </div>
     <div id="new-customer" class="panel-body" data-hook="login">
       <%= form_for @user, :as => :spree_user, :url => spree.registration_path(@user) do |f| %>


### PR DESCRIPTION
Fixes missing translation error by switching to translation in current spree/spree versions. This error occurred in 3-0-stable and master branches.