### PR TITLE
fix register path after signup fail

### DIFF
--- a/lib/views/frontend/spree/user_registrations/new.html.erb
+++ b/lib/views/frontend/spree/user_registrations/new.html.erb
@@ -6,7 +6,7 @@
         <h3 class="panel-title"><%= Spree.t(:new_customer) %></h3>
     </div>
       <div id="new-customer" class="panel-body" data-hook="login">
-          <%= form_for resource, :as => :spree_user, :url => spree.registration_path(@user) do |f| %>
+          <%= form_for resource, :as => :spree_user, :url => spree.registration_path do |f| %>
             <div data-hook="signup_inside_form">
               <%= render :partial => 'spree/shared/user_form', :locals => { :f => f } %>
               <p><%= f.submit Spree.t(:create), :class => 'btn btn-lg btn-success btn-block' %></p>


### PR DESCRIPTION
if you try to register an account with existing user name, it will fail but the URL spree.registration_path(@usee)  /signup.{FAIL_USER_EMAIL}, which will make the next registration fail. The POST URL should be always spree.registration_path => /signup