### PR TITLE
should not sign in user without confirmation

### DIFF
--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -17,13 +17,21 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
 
   # POST /resource/sign_up
   def create
-    @user = build_resource(spree_user_params)
-    if resource.save
-      set_flash_message(:notice, :signed_up)
-      sign_in(:spree_user, @user)
-      session[:spree_user_signup] = true
-      associate_user
-      respond_with resource, location: after_sign_up_path_for(resource)
+    build_resource(spree_user_params)
+    resource_saved = resource.save
+    yield resource if block_given?
+    if resource_saved
+      if resource.active_for_authentication?
+        set_flash_message :notice, :signed_up
+        sign_up(resource_name, resource)
+        session[:spree_user_signup] = true
+        associate_user
+        respond_with resource, location: after_sign_up_path_for(resource)
+      else
+        set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}"
+        expire_data_after_sign_in!
+        respond_with resource, location: after_inactive_sign_up_path_for(resource)
+      end
     else
       clean_up_passwords(resource)
       render :new

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -17,7 +17,7 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
 
   # POST /resource/sign_up
   def create
-    build_resource(spree_user_params)
+    @user = build_resource(spree_user_params)
     resource_saved = resource.save
     yield resource if block_given?
     if resource_saved


### PR DESCRIPTION
if you set Spree::Auth::Config[:confirmable] = true, you must check  first resource.active_for_authentication? to decide login user or not.
Otherwise you will get 403 error.

Please refer to devise source https://github.com/plataformatec/devise/blob/master/app/controllers/devise/registrations_controller.rb#L20