### PR TITLE
Provide missing duplicate sign-out translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
       already_signed_in: Already signed in.
+      already_signed_out: Already signed out.
   errors:
     messages:
       already_confirmed: was already confirmed


### PR DESCRIPTION
If you attempt to sign-out when already signed out the flash message reports
a translation is missing. This provides that missing translation. The flash message
is set by Devise[1] and most often happens if a user has multiple windows open,
logs out of one. Sees in the other window that they may not be logged out and then
logs out again.

1. https://github.com/plataformatec/devise/blob/master/app/controllers/devise/sessions_controller.rb#L61