### PR TITLE
fix bundle install error

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'poltergeist', '~> 1.5'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec-rails', '~> 3.0.0'
-  s.add_development_dependency 'sass-rails', '~> 4.0.0'
+  s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'shoulda-matchers', '~> 2.6.2'
   s.add_development_dependency 'simplecov', '~> 0.9.0'
   s.add_development_dependency 'spree_backend', spree_version


### PR DESCRIPTION
Bundle install failed with the following error.
So I fix it.
Can you check it?
```
Bundler could not find compatible versions for gem "sass":
  In Gemfile:
    spree_backend (~> 3.1.0.beta) ruby depends on
      bootstrap-sass (~> 3.3.1) ruby depends on
        sass (>= 3.3.0) ruby

    sass-rails (~> 4.0.0) ruby depends on
      sass (~> 3.2.0) ruby
Bundler could not find compatible versions for gem
"sprockets-rails":
  In Gemfile:
    spree_backend (~> 3.1.0.beta) ruby depends on
      sprockets-rails (~> 2.2) ruby

    spree_backend (~> 3.1.0.beta) ruby depends on
      sprockets-rails (~> 2.2) ruby

    spree (>= 0) ruby depends on
      spree_core (= 3.1.0.beta) ruby depends on
        rails (~> 4.2.2) ruby depends on
```