### PR TITLE
Make the registration error show up only on one page.

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -11,7 +11,7 @@ Spree::CheckoutController.class_eval do
     if params[:order][:email] =~ Devise.email_regexp && current_order.update_attribute(:email, params[:order][:email])
       redirect_to spree.checkout_path
     else
-      flash[:registration_error] = t(:email_is_invalid, :scope => [:errors, :messages])
+      flash.now[:registration_error] = t(:email_is_invalid, :scope => [:errors, :messages])
       @user = Spree::User.new
       render 'registration'
     end


### PR DESCRIPTION
Rails doc: "By default, adding values to the flash will make them available to the next request, but sometimes you may want to access those values in the same request. For example, if the create action fails to save a resource and you render the new template directly, that's not going to result in a new request, but you may still want to display a message using the flash. To do this, you can use flash.now"