### PR TITLE
Removed html link from text/plain email template

### DIFF
--- a/lib/views/frontend/spree/user_mailer/confirmation_instructions.text.erb
+++ b/lib/views/frontend/spree/user_mailer/confirmation_instructions.text.erb
@@ -1,5 +1,5 @@
 Welcome <%= @email %>!
 
-You can confirm your account email through the link below:
+You can confirm your account email through the url below:
 
-<%= link_to 'Confirm my account', @confirmation_url %>
+<%= @confirmation_url %>


### PR DESCRIPTION
Removed html link from text/plain email template