### PR TITLE
Inherit from Spree::Base

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -1,5 +1,5 @@
 module Spree
-  class User < ActiveRecord::Base
+  class User < Spree::Base
     include UserAddress
     include UserPaymentSource
 


### PR DESCRIPTION
There's any reason why we don't inherit User from Spree::Base?
This would solve some problems, like the ransack whitelisting

solidus also did this: https://github.com/solidusio/solidus_auth_devise/pull/20