### PR TITLE
Fix the devise helper signed_in_root_path call

### DIFF
--- a/lib/controllers/frontend/spree/user_confirmations_controller.rb
+++ b/lib/controllers/frontend/spree/user_confirmations_controller.rb
@@ -16,6 +16,6 @@ class Spree::UserConfirmationsController < Devise::ConfirmationsController
   protected
 
   def after_confirmation_path_for(resource_name, resource)
-    signed_in?(resource_name) ? spree.signed_in_root_path(resource) : spree.login_path
+    signed_in?(resource_name) ? signed_in_root_path(resource) : spree.login_path
   end
 end


### PR DESCRIPTION
signed_in_root_path is a helper from devise controller
so it needs to be called from controller and not from routes.

Fixes #280