### PR TITLE
set only :html as navigational format

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -111,7 +111,7 @@ Devise.setup do |config|
   # access, but formats like :xml or :json, should return 401.
   # If you have any extra navigational formats, like :iphone or :mobile, you
   # should add them to the navigational formats lists. Default is [:html]
-  config.navigational_formats = [:html, :json, :xml]
+  config.navigational_formats = [:html]
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not (yet) supported by Devise,


### PR DESCRIPTION
Redirects on json and xml requests are bad.