### PR TITLE
update devise dependency to 3.5.x

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pg'
   s.add_development_dependency 'poltergeist', '~> 1.5'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rspec-rails', '~> 3.0.0'
+  s.add_development_dependency 'rspec-rails', '~> 3.4.1'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'shoulda-matchers', '~> 2.6.2'
   s.add_development_dependency 'simplecov', '~> 0.9.0'

--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   spree_version = '~> 3.0.0'
 
-  s.add_dependency 'devise', '~> 3.4.1'
+  s.add_dependency 'devise', '~> 3.5.4'
   s.add_dependency 'devise-encryptable', '0.1.2'
   s.add_dependency 'json'
   s.add_dependency 'multi_json'


### PR DESCRIPTION
3.4.x has vulnerabilities: http://rubysec.com/advisories/CVE-2015-8314/