### PR TITLE
update devise dependency to 3.5.x

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   spree_version = '~> 3.1.0.beta'
 
-  s.add_dependency 'devise', '~> 3.4.1'
+  s.add_dependency 'devise', '~> 3.5.4'
   s.add_dependency 'devise-encryptable', '0.1.2'
   s.add_dependency 'json'
   s.add_dependency 'multi_json'


### PR DESCRIPTION
3.4.x has vulnerabilities: http://rubysec.com/advisories/CVE-2015-8314/

this is #312 for master branch