### PR TITLE
upgrading rspec-rails to 3.4.1, resolves cache errors on rails 4.2.5.1

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pg'
   s.add_development_dependency 'poltergeist', '~> 1.5'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rspec-rails', '~> 3.0.0'
+  s.add_development_dependency 'rspec-rails', '~> 3.4.1'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'shoulda-matchers', '~> 2.6.2'
   s.add_development_dependency 'simplecov', '~> 0.9.0'


### PR DESCRIPTION
backporting from master, fixes specs