### PR TITLE
fixes JS errors in feature specs for other older extensions

### DIFF
--- a/lib/views/frontend/spree/shared/_login_bar.html.erb
+++ b/lib/views/frontend/spree/shared/_login_bar.html.erb
@@ -1,1 +1,1 @@
-<script>Spree.fetch_account()</script>
+<script>if(typeof Spree.fetch_account !== 'undefined') Spree.fetch_account()</script>


### PR DESCRIPTION
Older extensions don't have included the new JS added to spree_auth_devise which causes JS errors (invoking undefined function). This fixes it for all extensions without updating all of them :) 