### PR TITLE
updated devise 3.5.1 to 3.5.4 for security issues

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   spree_version = '~> 3.1.0.beta'
 
-  s.add_dependency 'devise', '~> 3.5.1'
+  s.add_dependency 'devise', '~> 3.5.4'
   s.add_dependency 'devise-encryptable', '0.1.2'
   s.add_dependency 'json'
   s.add_dependency 'multi_json'


### PR DESCRIPTION
Updated devise from 3.5.1 to 3.5.4 to fix CVE-2015-8314: Devise Gem for Ruby Unauthorized Access Using Remember Me Cookie