### PR TITLE
Fix 2.4 stable build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
 env:
   - DB=mysql
   - DB=postgres
+before_install:
+  - gem update bundler
 before_script:
   - bundle exec rake test_app
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 1.9.3
   - 2.1.3
 env:
-  - DB=mysql
+  - DB=mysql2
   - DB=postgres
 before_install:
   - gem update bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'spree', '~> 2.4.0'
+gem 'mime-types', '< 3.0'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '2-4-stable'
+gem 'spree', '~> 2.4.0'
 
 gemspec

--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'devise', '~> 3.5.4'
   s.add_dependency 'devise-encryptable', '0.1.2'
-  s.add_dependency 'mime-types', '< 3.0'
 
   s.add_dependency 'json'
   s.add_dependency 'multi_json'

--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'devise', '~> 3.5.4'
   s.add_dependency 'devise-encryptable', '0.1.2'
+  s.add_dependency 'mime-types', '< 3.0'
 
   s.add_dependency 'json'
   s.add_dependency 'multi_json'


### PR DESCRIPTION
The fix has several parts:
* Specify DB=mysql2 so the mysql2 gem is actually loaded.
* Force use of mime-types < 3 to allow running on Ruby 1.9.3.
* Depend on a released version of spree to avoid any errors on the branch.
* Ensure latest Bundler is used to avoid weirdness where it would resolve one more gem each run.