### PR TITLE
include Spree::UserMethods in Spree::User

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -1,6 +1,7 @@
 module Spree
   class User < Spree::Base
     include UserAddress
+    include UserMethods
     include UserPaymentSource
 
     devise :database_authenticatable, :registerable, :recoverable,
@@ -9,8 +10,6 @@ module Spree
 
     acts_as_paranoid
     after_destroy :scramble_email_and_password
-
-    has_many :orders
 
     before_validation :set_login
 


### PR DESCRIPTION
Get rid of deprecation warning https://github.com/spree/spree/blob/master/core/config/initializers/user_class_extensions.rb#L7