### PR TITLE
CircleCI builds fixes + updated dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ env:
   - DB=postgres
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.2.4
 sudo: false

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,10 @@ machine:
   services:
     - postgresql
   ruby:
-    version: '2.2'
+    version: '2.2.4'
 
 dependencies:
+  pre:
+    - gem install bundler
   post:
     - bundle exec rake test_app

--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -26,19 +26,19 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', spree_version
 
   s.add_development_dependency 'capybara', '~> 2.4.1'
-  s.add_development_dependency 'coffee-rails', '~> 4.0.0'
-  s.add_development_dependency 'database_cleaner', '~> 1.2.0'
-  s.add_development_dependency 'email_spec', '~> 1.5.0'
-  s.add_development_dependency 'factory_girl', '~> 4.4'
+  s.add_development_dependency 'coffee-rails', '~> 4.1.1'
+  s.add_development_dependency 'database_cleaner', '~> 1.5'
+  s.add_development_dependency 'email_spec', '~> 2.0.0'
+  s.add_development_dependency 'factory_girl', '~> 4.7'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'
-  s.add_development_dependency 'poltergeist', '~> 1.5'
+  s.add_development_dependency 'poltergeist', '~> 1.6'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rspec-rails', '~> 3.4.1'
+  s.add_development_dependency 'rspec-rails', '~> 3.4.2'
   s.add_development_dependency 'shoulda-matchers', '~> 2.6.2'
-  s.add_development_dependency 'simplecov', '~> 0.9.0'
+  s.add_development_dependency 'simplecov', '~> 0.11.2'
   s.add_development_dependency 'spree_backend', spree_version
   s.add_development_dependency 'spree_frontend', spree_version
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
- testing against ruby `2.2.4` on CircleCI and Travis
- fixed CircleCI build (caused by problems described in https://discuss.circleci.com/t/bundler-fails-to-find-appropriate-version-despite-installing-appropriate-version-earlier-in-the-build/2815) 
- development dependencies updated
- `coffee-rails` updated to `4.1.x` match the same version of Spree