### PR TITLE
removed ' helper 'spree/admin/tables' ' from user password controller

### DIFF
--- a/lib/controllers/backend/spree/admin/user_passwords_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_passwords_controller.rb
@@ -6,7 +6,6 @@ class Spree::Admin::UserPasswordsController < Devise::PasswordsController
   include Spree::Core::ControllerHelpers::Store
 
   helper 'spree/admin/navigation'
-  helper 'spree/admin/tables'
   layout 'spree/layouts/admin'
 
   # Overridden due to bug in Devise.


### PR DESCRIPTION
This helper doesn't exist in the spree core or spree backend