### PR TITLE
Remove inclusion of tables helper as its been removed in spree

### DIFF
--- a/lib/controllers/backend/spree/admin/user_passwords_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_passwords_controller.rb
@@ -6,7 +6,6 @@ class Spree::Admin::UserPasswordsController < Devise::PasswordsController
   include Spree::Core::ControllerHelpers::Store
 
   helper 'spree/admin/navigation'
-  helper 'spree/admin/tables'
   layout 'spree/layouts/admin'
 
   # Overridden due to bug in Devise.

--- a/lib/controllers/backend/spree/admin/user_sessions_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_sessions_controller.rb
@@ -6,7 +6,6 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
   include Spree::Core::ControllerHelpers::Store
 
   helper 'spree/admin/navigation'
-  helper 'spree/admin/tables'
   layout :resolve_layout
 
   def create


### PR DESCRIPTION
`TablesHelper` was removed [here](https://github.com/spree/spree/pull/7282)