### PR TITLE
Update spree version in 3-1-stable gemspec

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '~> 3.1.0.beta'
+  spree_version = '~> 3.1.0'
 
   s.add_dependency 'devise', '~> 3.5.4'
   s.add_dependency 'devise-encryptable', '0.1.2'


### PR DESCRIPTION
It should always run on the non-beta version of spree