### PR TITLE
Optimize callback and change login field on email change

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -11,7 +11,7 @@ module Spree
     acts_as_paranoid
     after_destroy :scramble_email_and_password
 
-    before_validation :set_login
+    before_validation :set_login, if: :email_changed?
 
     users_table_name = User.table_name
     roles_table_name = Role.table_name
@@ -35,7 +35,7 @@ module Spree
 
       def set_login
         # for now force login to be same as email, eventually we will make this configurable, etc.
-        self.login ||= self.email if self.email
+        self.login = self.email
       end
 
       def scramble_email_and_password


### PR DESCRIPTION
Issue:
Admin changes email of a user but the login field is not changed for that user. User is able to login only through old email and not able to login through new email of user.

In this callback `login` field will only be assigned if its `nil` which means at the time of user creation. On every other case this callback will run and nothing change would happen.
Now, this callback will only run if email is changed and new value of email will be assigned to login.