### PR TITLE
add email instance varaible in confirmation_instructions

### DIFF
--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -8,6 +8,7 @@ module Spree
 
     def confirmation_instructions(user, token, opts={})
       @confirmation_url = spree.spree_user_confirmation_url(:confirmation_token => token, :host => Spree::Store.current.url)
+      @email = user.email
 
       mail to: user.email, from: from_address, subject: Spree::Store.current.name + ' ' + I18n.t(:subject, :scope => [:devise, :mailer, :confirmation_instructions])
     end


### PR DESCRIPTION
Currently we are using @email instance variable in confirmation_instructions.text.erb which is not define anywhere.
