### PR TITLE
Spree API: Generate `user.spree_api_key` only if API is available

### DIFF
--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -60,7 +60,7 @@ def create_admin_user
       role = Spree::Role.find_or_create_by(name: 'admin')
       admin.spree_roles << role
       admin.save
-      admin.generate_spree_api_key!
+      admin.generate_spree_api_key! if Spree::Auth::Engine.api_available?
       say "Done!"
     else
       say "There was some problems with persisting new admin user:"

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -49,12 +49,12 @@ module Spree
         ApplicationController.send :include, Spree::AuthenticationHelpers
       end
 
-      def self.backend_available?
-        @@backend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Backend::Engine')
+      def self.api_available?
+        @@api_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Api::Engine')
       end
 
-      def self.dash_available?
-        @@dash_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Dash::Engine')
+      def self.backend_available?
+        @@backend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Backend::Engine')
       end
 
       def self.frontend_available?


### PR DESCRIPTION
This was throwing errors if `spree_api` gem was not used.