### PR TITLE
use proper scoping to find translations related to order states

### DIFF
--- a/lib/views/frontend/spree/users/show.html.erb
+++ b/lib/views/frontend/spree/users/show.html.erb
@@ -27,7 +27,7 @@
         <tr>
           <td class="order-number"><%= link_to order.number, order_url(order) %></td>
           <td class="order-date"><%= l order.completed_at.to_date %></td>
-          <td class="order-status"><%= Spree.t("order_state.#{order.state}").titleize %></td>
+          <td class="order-status"><%= Spree.t("order_states.#{order.state}").titleize %></td>
           <td class="order-payment-state"><%= Spree.t("payment_states.#{order.payment_state}").titleize if order.payment_state %></td>
           <td class="order-shipment-state"><%= Spree.t("shipment_states.#{order.shipment_state}").titleize if order.shipment_state %></td>
           <td class="lead text-primary order-total"><%= order.display_total %></td>


### PR DESCRIPTION
In reference to the PR #7955 this change is needed to ensure the use of proper scoping to find the translations related to order's states.
<img width="1051" alt="missing_translations" src="https://cloud.githubusercontent.com/assets/13478899/26752900/e4c0f570-4877-11e7-86ad-157835a25193.png">
