### PR TITLE
add migrations from engine spree_auth

### DIFF
--- a/lib/generators/spree/auth/install/install_generator.rb
+++ b/lib/generators/spree/auth/install/install_generator.rb
@@ -20,7 +20,7 @@ module Spree
         end
 
         def add_migrations
-          run 'bundle exec rake railties:install:migrations FROM=spree_auth_devise'
+          run 'bundle exec rake railties:install:migrations FROM=spree_auth'
         end
 
         def run_migrations


### PR DESCRIPTION
Tried adding the extension in a fresh spree application and couldn't get the migrations added to my application from `bundle exec rails g spree:auth:install`. 

The reason for this behaviour seems to be the wrong value of environment variable FROM in the command `bundle exec rake railties:install:migrations FROM=spree_auth_device`. It should be spree_auth(name of the engine) instead of spree_auth_device.

I do not believe that changing the name of the engine to spree_auth_devise would be a good idea so I made the change in the command only.

Please check.