### PR TITLE
Make registrations configurable [WIP]

### DIFF
--- a/app/models/spree/auth_configuration.rb
+++ b/app/models/spree/auth_configuration.rb
@@ -3,5 +3,6 @@ module Spree
     preference :registration_step, :boolean, default: true
     preference :signout_after_password_change, :boolean, default: true
     preference :confirmable, :boolean, default: false
+    preference :registerable, :boolean, default: true
   end
 end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -4,9 +4,10 @@ module Spree
     include UserMethods
     include UserPaymentSource
 
-    devise :database_authenticatable, :registerable, :recoverable,
+    devise :database_authenticatable, :recoverable,
            :rememberable, :trackable, :validatable, :encryptable, encryptor: 'authlogic_sha512'
     devise :confirmable if Spree::Auth::Config[:confirmable]
+    devise :registerable if Spree::Auth::Config[:registerable]
 
     acts_as_paranoid
     after_destroy :scramble_email_and_password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,8 @@ Spree::Core::Engine.add_routes do
     get '/login' => 'user_sessions#new', :as => :login
     post '/login' => 'user_sessions#create', :as => :create_new_session
     get '/logout' => 'user_sessions#destroy', :as => :logout
-    get '/signup' => 'user_registrations#new', :as => :signup
-    post '/signup' => 'user_registrations#create', :as => :registration
+    get '/signup' => 'user_registrations#new', :as => :signup if Spree::Auth::Config[:registerable]
+    post '/signup' => 'user_registrations#create', :as => :registration if Spree::Auth::Config[:registerable]
     get '/password/recover' => 'user_passwords#new', :as => :recover_password
     post '/password/recover' => 'user_passwords#create', :as => :reset_password
     get '/password/change' => 'user_passwords#edit', :as => :edit_password

--- a/lib/views/frontend/spree/user_sessions/new.html.erb
+++ b/lib/views/frontend/spree/user_sessions/new.html.erb
@@ -10,8 +10,10 @@
           <% end %>
           <%= render :partial => 'spree/shared/login' %>
           <div class="text-center">
-            <%= Spree.t(:or) %> 
-                <%= link_to Spree.t(:create_a_new_account), spree.signup_path %> |
+            <%= Spree.t(:or) %>
+                <% if Spree::Auth::Config[:registerable] %>
+                  <%= link_to Spree.t(:create_a_new_account), spree.signup_path %> |
+                <% end %>
                 <%= link_to Spree.t(:forgot_password), spree.recover_password_path %>
           </div>
           <div data-hook="login_extras"></div>


### PR DESCRIPTION
I started on a change that allows you to disable user registrations. It partially works and hides the signup link however if you manually visit /signup you can still load the page and sign up so something is not quite right.

Would be great if someone could help me out with the last bit.