### PR TITLE
Fixes email_validator deprecation warning

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,4 +1,3 @@
-require 'spree/core/validators/email'
 Spree::CheckoutController.class_eval do
   before_action :check_authorization
   before_action :check_registration, except: [:registration, :update_registration]


### PR DESCRIPTION
EmailValidator was moved to `app/validators` in spree/master. `spree/core/validators/email` is deprecated.

EmailValidator was removed from `checkout_controller` in https://github.com/spree/spree_auth_devise/commit/c199b6c1084aa19d36ad79448b48b40e550ebab9#diff-6d07fe992144746adf8f712814389d5c