### PR TITLE
Set mysql2 to ~> 0.3.18 for Travis-Ci tests.

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_bot', '~> 4.7'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'launchy'
-  s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'mysql2', '~> 0.3.18'
   s.add_development_dependency 'pg', '~> 0.18'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Simple gem version deceleration for Travis CI tests.