### PR TITLE
Makes Devise validatable be configurable

### DIFF
--- a/app/models/spree/auth_configuration.rb
+++ b/app/models/spree/auth_configuration.rb
@@ -3,5 +3,6 @@ module Spree
     preference :registration_step, :boolean, default: true
     preference :signout_after_password_change, :boolean, default: true
     preference :confirmable, :boolean, default: false
+    preference :validatable, :boolean, default: true
   end
 end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -5,8 +5,9 @@ module Spree
     include UserPaymentSource
 
     devise :database_authenticatable, :registerable, :recoverable,
-           :rememberable, :trackable, :validatable, :encryptable, encryptor: 'authlogic_sha512'
+           :rememberable, :trackable, :encryptable, encryptor: 'authlogic_sha512'
     devise :confirmable if Spree::Auth::Config[:confirmable]
+    devise :validatable if Spree::Auth::Config[:validatable]
 
     acts_as_paranoid
     after_destroy :scramble_email_and_password


### PR DESCRIPTION
The `Validatable` class makes the email to be unique, so even if we customize this behavior in devise, we won't be able to create users with the same email because of this class.

In order to make it possible to have a [multiple authentication keys](https://github.com/plataformatec/devise/wiki/How-to:-Scope-login-to-subdomain) we need this class to not be included