### PR TITLE
Fix password length regex, error message

### DIFF
--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -8,8 +8,8 @@ def prompt_for_admin_password
   else
     password = ask('Password [spree123]: ') do |q|
       q.echo = false
-      q.validate = /^(|.{5,40})$/
-      q.responses[:not_valid] = 'Invalid password. Must be at least 5 characters long.'
+      q.validate = /^(|.{6,40})$/
+      q.responses[:not_valid] = 'Invalid password. Must be at least 6 characters long.'
       q.whitespace = :strip
     end
     password = 'spree123' if password.blank?


### PR DESCRIPTION
<img width="531" alt="spree_error" src="https://user-images.githubusercontent.com/8337530/41373412-ed06f518-6f6d-11e8-9fbe-c18955711d88.png">

If minimum password length is 6 characters, shouldn't the error message and regex check for 6 instead of current 5 characters?