### PR TITLE
Remove reference to the old EmailValidator

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,4 +1,3 @@
-require 'spree/core/validators/email'
 Spree::CheckoutController.class_eval do
   before_action :check_authorization
   before_action :check_registration, except: [:registration, :update_registration]

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,3 +1,4 @@
+require 'spree/core/validators/email' if Spree.version.to_f < 3.5
 Spree::CheckoutController.class_eval do
   before_action :check_authorization
   before_action :check_registration, except: [:registration, :update_registration]


### PR DESCRIPTION
It was removed in https://github.com/spree/spree/commit/f80b0c30cac356f465ba35d1a98d29b7bd945f54