### PR TITLE
Format The Forms To Match The Main Spree Project

### DIFF
--- a/lib/controllers/frontend/spree/user_passwords_controller.rb
+++ b/lib/controllers/frontend/spree/user_passwords_controller.rb
@@ -5,7 +5,8 @@ class Spree::UserPasswordsController < Devise::PasswordsController
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
-  if Gem.loaded_specs['spree_i18n']
+
+  if defined?(SpreeI18n::ControllerLocaleHelper)
     include SpreeI18n::ControllerLocaleHelper
   end
 

--- a/lib/controllers/frontend/spree/user_passwords_controller.rb
+++ b/lib/controllers/frontend/spree/user_passwords_controller.rb
@@ -5,6 +5,9 @@ class Spree::UserPasswordsController < Devise::PasswordsController
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
+  if Gem.loaded_specs['spree_i18n']
+    include SpreeI18n::ControllerLocaleHelper
+  end
 
   # Overridden due to bug in Devise.
   #   respond_with resource, :location => new_session_path(resource_name)

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -5,6 +5,9 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
+  if Gem.loaded_specs['spree_i18n']
+    include SpreeI18n::ControllerLocaleHelper
+  end
 
   before_action :check_permissions, only: [:edit, :update]
   skip_before_action :require_no_authentication

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -5,7 +5,8 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
-  if Gem.loaded_specs['spree_i18n']
+
+  if defined?(SpreeI18n::ControllerLocaleHelper)
     include SpreeI18n::ControllerLocaleHelper
   end
 

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -5,6 +5,9 @@ class Spree::UserSessionsController < Devise::SessionsController
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
+  if Gem.loaded_specs['spree_i18n']
+    include SpreeI18n::ControllerLocaleHelper
+  end
 
   def create
     authenticate_spree_user!

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -5,7 +5,8 @@ class Spree::UserSessionsController < Devise::SessionsController
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
-  if Gem.loaded_specs['spree_i18n']
+
+  if defined?(SpreeI18n::ControllerLocaleHelper)
     include SpreeI18n::ControllerLocaleHelper
   end
 

--- a/lib/views/frontend/spree/checkout/_new_user.html.erb
+++ b/lib/views/frontend/spree/checkout/_new_user.html.erb
@@ -7,7 +7,7 @@
       <%= form_for @user, :as => :spree_user, :url => spree.registration_path(@user) do |f| %>
         <div data-hook="signup_inside_form">
           <%= render :partial => 'spree/shared/user_form', :locals => { :f => f } %>
-          <p><%= f.submit Spree.t(:create), :class => 'btn btn-lg btn-success btn-block' %></p>
+          <div><%= f.submit Spree.t(:create), :class => 'btn btn-lg btn-success btn-block' %></div>
         </div>
       <% end %>
       <div class="text-center">

--- a/lib/views/frontend/spree/checkout/registration.html.erb
+++ b/lib/views/frontend/spree/checkout/registration.html.erb
@@ -12,11 +12,11 @@
         </div>
         <div id="guest_checkout" class="panel-body" data-hook>
           <%= form_for @order, :url => update_checkout_registration_path, :method => :put, :html => { :id => 'checkout_form_registration' } do |f| %>
-            <p class="form-group">
+            <div class="form-group">
               <%= f.label :email, Spree.t(:email), class: 'required', title: 'required' %>
               <%= f.email_field :email, :class => 'form-control title', :placeholder => Spree.t(:email) %>
-            </p>
-            <p><%= f.submit Spree.t(:continue), :class => 'btn btn-lg btn-success btn-block' %></p>
+            </div>
+            <div><%= f.submit Spree.t(:continue), :class => 'btn btn-lg btn-success btn-block' %></div>
           <% end %>
         </div>
       </div>

--- a/lib/views/frontend/spree/checkout/registration.html.erb
+++ b/lib/views/frontend/spree/checkout/registration.html.erb
@@ -12,7 +12,8 @@
         </div>
         <div id="guest_checkout" class="panel-body" data-hook>
           <%= form_for @order, :url => update_checkout_registration_path, :method => :put, :html => { :id => 'checkout_form_registration' } do |f| %>
-            <p>
+            <p class="form-group">
+              <%= f.label :email, Spree.t(:email), class: 'required', title: 'required' %>
               <%= f.email_field :email, :class => 'form-control title', :placeholder => Spree.t(:email) %>
             </p>
             <p><%= f.submit Spree.t(:continue), :class => 'btn btn-lg btn-success btn-block' %></p>

--- a/lib/views/frontend/spree/shared/_login.html.erb
+++ b/lib/views/frontend/spree/shared/_login.html.erb
@@ -1,18 +1,18 @@
 <%= form_for Spree::User.new, :as => :spree_user, :url => spree.create_new_session_path do |f| %>
   <div id="password-credentials">
-    <p class="form-group">
+    <div class="form-group">
       <%= f.label :email, Spree.t(:email) %>
       <%= f.email_field :email, placeholder: "#{Spree.t(:email)}", :class => 'form-control', :tabindex => 1, autofocus: true %>
-    </p>
-    <p class="form-group">
+    </div>
+    <div class="form-group">
       <%= f.label :password, Spree.t(:password) %>
       <%= f.password_field :password, placeholder: "#{Spree.t(:password)}", :class => 'form-control', :tabindex => 2 %>
-    </p>
+    </div>
   </div>
-  <p>
+  <div>
     <%= f.check_box :remember_me, :tabindex => 3 %>
     <%= f.label :remember_me, Spree.t(:remember_me) %>
-  </p>
+  </div>
 
-  <p><%= f.submit Spree.t(:login), :class => 'btn btn-lg btn-success btn-block', :tabindex => 4 %></p>
+  <div><%= f.submit Spree.t(:login), :class => 'btn btn-lg btn-success btn-block', :tabindex => 4 %></div>
 <% end %>

--- a/lib/views/frontend/spree/shared/_login.html.erb
+++ b/lib/views/frontend/spree/shared/_login.html.erb
@@ -2,11 +2,11 @@
   <div id="password-credentials">
     <p class="form-group">
       <%= f.label :email, Spree.t(:email) %>
-      <%= f.email_field :email, :class => 'form-control', :tabindex => 1, autofocus: true %>
+      <%= f.email_field :email, placeholder: "#{Spree.t(:email)}", :class => 'form-control', :tabindex => 1, autofocus: true %>
     </p>
     <p class="form-group">
       <%= f.label :password, Spree.t(:password) %>
-      <%= f.password_field :password, :class => 'form-control', :tabindex => 2 %>
+      <%= f.password_field :password, placeholder: "#{Spree.t(:password)}", :class => 'form-control', :tabindex => 2 %>
     </p>
   </div>
   <p>

--- a/lib/views/frontend/spree/shared/_login.html.erb
+++ b/lib/views/frontend/spree/shared/_login.html.erb
@@ -1,10 +1,10 @@
 <%= form_for Spree::User.new, :as => :spree_user, :url => spree.create_new_session_path do |f| %>
   <div id="password-credentials">
-    <p>
+    <p class="form-group">
       <%= f.label :email, Spree.t(:email) %>
       <%= f.email_field :email, :class => 'form-control', :tabindex => 1, autofocus: true %>
     </p>
-    <p>
+    <p class="form-group">
       <%= f.label :password, Spree.t(:password) %>
       <%= f.password_field :password, :class => 'form-control', :tabindex => 2 %>
     </p>

--- a/lib/views/frontend/spree/shared/_user_form.html.erb
+++ b/lib/views/frontend/spree/shared/_user_form.html.erb
@@ -1,13 +1,17 @@
 <fieldset id="password-credentials">
-  <div class="form-group">
+  <p class="form-group">
+    <%= f.label :email, Spree.t(:email), class: 'required', title: 'required' %>
     <%= f.email_field :email, :class => 'form-control', :placeholder => Spree.t(:email) %>
-  </div>
+  </p>
   <hr />
-  <div class="form-group">
+  <p class="form-group">
+    <%= f.label :password, Spree.t(:password), class: 'required', title: 'required' %>
     <%= f.password_field :password, :class => 'form-control', :placeholder => Spree.t(:password) %>
-  </div> 
-  <div class="form-group">
+
+  </p>
+  <p class="form-group">
+    <%= f.label :password_confirmation, Spree.t(:password_confirmation), class: 'required', title: 'required' %>
     <%= f.password_field :password_confirmation, :class => 'form-control', :placeholder => Spree.t(:confirm_password) %>
-  </div> 
+  </p>
 </fieldset>
 <div data-hook="signup_below_password_fields"></div>

--- a/lib/views/frontend/spree/shared/_user_form.html.erb
+++ b/lib/views/frontend/spree/shared/_user_form.html.erb
@@ -1,17 +1,17 @@
 <fieldset id="password-credentials">
-  <p class="form-group">
+  <div class="form-group">
     <%= f.label :email, Spree.t(:email), class: 'required', title: 'required' %>
     <%= f.email_field :email, :class => 'form-control', :placeholder => Spree.t(:email) %>
-  </p>
+  </div>
   <hr />
-  <p class="form-group">
+  <div class="form-group">
     <%= f.label :password, Spree.t(:password), class: 'required', title: 'required' %>
     <%= f.password_field :password, :class => 'form-control', :placeholder => Spree.t(:password) %>
 
-  </p>
-  <p class="form-group">
+  </div>
+  <div class="form-group">
     <%= f.label :password_confirmation, Spree.t(:password_confirmation), class: 'required', title: 'required' %>
     <%= f.password_field :password_confirmation, :class => 'form-control', :placeholder => Spree.t(:confirm_password) %>
-  </p>
+  </div>
 </fieldset>
 <div data-hook="signup_below_password_fields"></div>

--- a/lib/views/frontend/spree/user_passwords/edit.html.erb
+++ b/lib/views/frontend/spree/user_passwords/edit.html.erb
@@ -6,11 +6,11 @@
     </div>
     <div class="panel-body">
       <%= form_for @spree_user, :as => :spree_user, :url => spree.update_password_path, :method => :put do |f| %>
-        <p>
+        <p class="form-group">
           <%= f.label :password, Spree.t(:password) %>
           <%= f.password_field :password, :class => "form-control" %>
         </p>
-        <p>
+        <p class="form-group">
           <%= f.label :password_confirmation, Spree.t(:confirm_password) %>
           <%= f.password_field :password_confirmation, :class => "form-control" %>
         </p>

--- a/lib/views/frontend/spree/user_passwords/edit.html.erb
+++ b/lib/views/frontend/spree/user_passwords/edit.html.erb
@@ -6,14 +6,14 @@
     </div>
     <div class="panel-body">
       <%= form_for @spree_user, :as => :spree_user, :url => spree.update_password_path, :method => :put do |f| %>
-        <p class="form-group">
+        <div class="form-group">
           <%= f.label :password, Spree.t(:password) %>
           <%= f.password_field :password, :class => "form-control" %>
-        </p>
-        <p class="form-group">
+        </div>
+        <div class="form-group">
           <%= f.label :password_confirmation, Spree.t(:confirm_password) %>
           <%= f.password_field :password_confirmation, :class => "form-control" %>
-        </p>
+        </div>
         <%= f.hidden_field :reset_password_token %>
         <%= f.submit Spree.t(:update), :class => 'btn btn-lg btn-success btn-block' %>
       <% end %>

--- a/lib/views/frontend/spree/user_passwords/new.html.erb
+++ b/lib/views/frontend/spree/user_passwords/new.html.erb
@@ -8,7 +8,7 @@
       <p><%= Spree.t(:instructions_to_reset_password) %></p>
 
       <%= form_for Spree::User.new, :as => :spree_user, :url => spree.reset_password_path do |f| %>
-        <p>
+        <p class="form-group">
           <%= f.label :email, Spree.t(:email) %>
           <%= f.email_field :email, :class => "form-control" %>
         </p>

--- a/lib/views/frontend/spree/user_passwords/new.html.erb
+++ b/lib/views/frontend/spree/user_passwords/new.html.erb
@@ -8,13 +8,13 @@
       <p><%= Spree.t(:instructions_to_reset_password) %></p>
 
       <%= form_for Spree::User.new, :as => :spree_user, :url => spree.reset_password_path do |f| %>
-        <p class="form-group">
+        <div class="form-group">
           <%= f.label :email, Spree.t(:email) %>
           <%= f.email_field :email, :class => "form-control" %>
-        </p>
-        <p>
+        </div>
+        <div>
           <%= f.submit Spree.t(:reset_password), :class => 'btn btn-lg btn-success btn-block' %>
-        </p>
+        </div>
       <% end %>
     </div>
   </div>

--- a/lib/views/frontend/spree/user_registrations/new.html.erb
+++ b/lib/views/frontend/spree/user_registrations/new.html.erb
@@ -9,11 +9,11 @@
           <%= form_for resource, :as => :spree_user, :url => spree.registration_path do |f| %>
             <div data-hook="signup_inside_form">
               <%= render :partial => 'spree/shared/user_form', :locals => { :f => f } %>
-              <p><%= f.submit Spree.t(:create), :class => 'btn btn-lg btn-success btn-block' %></p>
+              <div><%= f.submit Spree.t(:create), :class => 'btn btn-lg btn-success btn-block' %></div>
             </div>
           <% end %>
           <div class="text-center">
-            <%= Spree.t(:or) %> 
+            <%= Spree.t(:or) %>
               <%= link_to Spree.t(:login_as_existing), spree.login_path %>
           </div>
           <div data-hook="login_extras"></div>

--- a/lib/views/frontend/spree/users/edit.html.erb
+++ b/lib/views/frontend/spree/users/edit.html.erb
@@ -5,12 +5,12 @@
     </div>
     <div class="panel-body">
       <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @user } %>
-      
+
       <%= form_for Spree::User.new, :as => @user, :url => spree.user_path(@user), :method => :put do |f| %>
         <%= render :partial => 'spree/shared/user_form', :locals => { :f => f } %>
-        <p>
+        <div>
           <%= f.submit Spree.t(:update), :class => 'btn btn-primary' %>
-        </p>
+        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
## Unify Form Layout Throughout Spree & The Spree Extensions. 
Formatted the forms to use both ```<input>``` and ```<label>``` elements, and  also use ```<div class="form-group">``` tags for the parent elements. 

If this change is merged I will fork the main Spree project and edit the checkout address form to match.

## Improve Internationalization 
Added a check to see ```if defined?(SpreeI18n::ControllerLocaleHelper)``` is being used, if true, then add ```include SpreeI18n::ControllerLocaleHelper``` to render the  login and registration pages in the current selected language.