### PR TITLE
Added deface as a dependency

### DIFF
--- a/spree_auth_devise.gemspec
+++ b/spree_auth_devise.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   spree_version = '>= 3.1.0', '< 5.0'
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_extension'
+  s.add_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'capybara', '~> 2.7'
   s.add_development_dependency 'capybara-screenshot'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here