### PR TITLE
Fixes errors around guest_token when upgrading to Spree 3.7

### DIFF
--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,18 +1,14 @@
 # Merges users orders to their account after sign in and sign up.
 Warden::Manager.after_set_user except: :fetch do |user, auth, _opts|
-  guest_token = auth.cookies.signed[:guest_token]
-  token       = auth.cookies.signed[:token]
+  token = auth.cookies.signed[:guest_token] || auth.cookies.signed[:token]
+  token_attr = Spree::Order.has_attribute?(:token) ? :token : :guest_token
 
   if token.present? && user.is_a?(Spree::User)
-    Spree::Order.incomplete.where(token: token, user_id: nil).each do |order|
-      order.associate_user!(user)
-    end
-  elsif guest_token.present? && user.is_a?(Spree::User)
-    Spree::Order.incomplete.where(guest_token: guest_token, user_id: nil).each do |order|
+    Spree::Order.incomplete.where(token_attr => token, user_id: nil).each do |order|
       order.associate_user!(user)
     end
   end
-end
+end 
 
 Warden::Manager.before_logout do |_user, auth, _opts|
   auth.cookies.delete(:guest_token)

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -132,6 +132,26 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
         end
       end
 
+      context 'with a guest_token from a pre-3.7 version of Spree present' do
+        before do
+          request.cookie_jar.signed[:guest_token] = 'ABC'
+          request.cookie_jar.signed[:token] = 'DEF'
+        end
+          
+        it 'assigns the correct token attribute for the order' do 
+          if Spree.version.to_f > 3.6
+            order = create(:order, email: user.email, token: 'ABC', user_id: nil, created_by_id: nil)
+          else
+            order = create(:order, email: user.email, guest_token: 'ABC', user_id: nil, created_by_id: nil)
+          end
+          spree_post :create, spree_user: { email: user.email, password: 'secret' }
+
+          order.reload
+          expect(order.user_id).to eq user.id
+          expect(order.created_by_id).to eq user.id
+        end 
+      end
+
       context "and html format is used" do
         it "redirects to default after signing in" do
           spree_post :create, spree_user: { email: user.email, password: 'secret' }


### PR DESCRIPTION
Fixes an error raised by `spree_current_user` after upgrading to Spree 3.7 from an earlier version, where a previous user may have the `guest_token` cookie present, but the `guest_token` column on `Spree::Order` is no longer present (as it was renamed to `token` in 3.7).  Error raised is:

`ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR: column spree_orders.guest_token does not exist LINE 1: ..." WHERE "spree_orders"."completed_at" IS NULL AND "spree_ord... ^ : SELECT "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."guest_token" = $1 AND "spree_orders"."user_id" IS NULL`