### PR TITLE
Remove assets and store_link endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,6 @@ Spree::Core::Engine.add_routes do
   get '/checkout/registration' => 'checkout#registration', :as => :checkout_registration
   put '/checkout/registration' => 'checkout#update_registration', :as => :update_checkout_registration
 
-  get '/account_link' => 'store#account_link'
   resource :account, controller: 'users'
 
   namespace :admin, path: Spree.admin_path do

--- a/lib/assets/javascripts/spree/backend/spree_auth.js.erb
+++ b/lib/assets/javascripts/spree/backend/spree_auth.js.erb
@@ -1,1 +1,0 @@
-//= require spree/backend

--- a/lib/assets/javascripts/spree/frontend/account.js
+++ b/lib/assets/javascripts/spree/frontend/account.js
@@ -1,8 +1,0 @@
-Spree.fetch_account = function() {
-  return $.ajax({
-    url: Spree.pathFor("account_link"),
-    success: function(data) {
-      return $(data).insertBefore("li#search-bar");
-    }
-  });
-};

--- a/lib/assets/javascripts/spree/frontend/spree_auth.js.erb
+++ b/lib/assets/javascripts/spree/frontend/spree_auth.js.erb
@@ -1,2 +1,0 @@
-//= require spree/frontend
-//= require spree/frontend/account

--- a/lib/assets/stylesheets/spree/backend/spree_auth.css.erb
+++ b/lib/assets/stylesheets/spree/backend/spree_auth.css.erb
@@ -1,3 +1,0 @@
-/*
- *= require spree/backend
-*/

--- a/lib/assets/stylesheets/spree/frontend/spree_auth.css.erb
+++ b/lib/assets/stylesheets/spree/frontend/spree_auth.css.erb
@@ -1,3 +1,0 @@
-/*
- *= require spree/frontend
-*/

--- a/lib/controllers/frontend/spree/store_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/store_controller_decorator.rb
@@ -1,7 +1,0 @@
-module Spree::StoreControllerDecorator
-  def account_link
-    render partial: 'spree/shared/link_to_account'
-    fresh_when(spree_current_user)
-  end
-end
-Spree::StoreController.prepend(Spree::StoreControllerDecorator)

--- a/lib/generators/spree/auth/install/install_generator.rb
+++ b/lib/generators/spree/auth/install/install_generator.rb
@@ -10,10 +10,6 @@ module Spree
           paths.flatten
         end
 
-        def add_javascripts
-          append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/spree_auth\n"
-        end
-
         def generate_devise_key
           return if ENV['CI']
           template 'config/initializers/devise.rb', 'config/initializers/devise.rb'


### PR DESCRIPTION
This is replaced in 4.1 via https://github.com/spree/spree/pull/9780/commits/f5dc6d9afbff05ec762e47e810fca98246112558