### PR TITLE
[SDP-314] Adds currently chosen store info to reset password emails

### DIFF
--- a/app/controllers/spree/api/v2/storefront/passwords_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/passwords_controller.rb
@@ -3,11 +3,12 @@ module Spree
     module V2
       module Storefront
         class PasswordsController < ::Spree::Api::V2::BaseController
+          include Spree::Core::ControllerHelpers::Store
 
           def create
             user = Spree.user_class.find_by(email: params[:user][:email])
 
-            if user&.send_reset_password_instructions
+            if user&.send_reset_password_instructions(current_store)
               head :ok
             else
               head :not_found

--- a/app/controllers/spree/user_passwords_controller.rb
+++ b/app/controllers/spree/user_passwords_controller.rb
@@ -20,7 +20,7 @@ class Spree::UserPasswordsController < Devise::PasswordsController
   #   respond_with resource, :location => spree.login_path
   #
   def create
-    self.resource = resource_class.send_reset_password_instructions(params[resource_name])
+    self.resource = resource_class.send_reset_password_instructions(params[resource_name], current_store)
 
     if resource.errors.empty?
       set_flash_message(:notice, :send_instructions) if is_navigational_format?

--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -1,9 +1,13 @@
 module Spree
   class UserMailer < BaseMailer
     def reset_password_instructions(user, token, *_args)
-      @edit_password_reset_url = spree.edit_spree_user_password_url(reset_password_token: token, host: Spree::Store.current.url)
+      current_store_id = _args.inject(:merge)[:current_store_id]
+      @current_store = Spree::Store.find(current_store_id) || Spree::Store.current
+      @locale = @current_store.has_attribute?(:default_locale) ? @current_store.default_locale : I18n.default_locale
+      I18n.locale = @locale if @locale.present?
+      @edit_password_reset_url = spree.edit_spree_user_password_url(reset_password_token: token, host: @current_store.url)
 
-      mail to: user.email, from: from_address, subject: Spree::Store.current.name + ' ' + I18n.t(:subject, scope: [:devise, :mailer, :reset_password_instructions])
+      mail to: user.email, from: from_address, subject: @current_store.name + ' ' + I18n.t(:subject, scope: [:devise, :mailer, :reset_password_instructions])
     end
 
     def confirmation_instructions(user, token, _opts = {})

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -27,6 +27,23 @@ module Spree
       has_spree_role?('admin')
     end
 
+    def self.send_reset_password_instructions(attributes={}, current_store)
+      recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
+      recoverable.send_reset_password_instructions(current_store) if recoverable.persisted?
+      recoverable
+    end
+
+    def send_reset_password_instructions(current_store)
+      token = set_reset_password_token
+      send_reset_password_instructions_notification(token, current_store.id)
+
+      token
+    end
+
+    def send_reset_password_instructions_notification(token, current_store_id)
+      send_devise_notification(:reset_password_instructions, token, { current_store_id: current_store_id })
+    end
+
     protected
 
     def password_required?

--- a/app/views/spree/user_mailer/confirmation_instructions.text.erb
+++ b/app/views/spree/user_mailer/confirmation_instructions.text.erb
@@ -1,5 +1,5 @@
-Welcome <%= @email %>!
+<%= Spree.t('confirmation_instructions.welcome', email: @email) %>
 
-You can confirm your account email through the url below:
+<%= Spree.t('confirmation_instructions.confirm') %>
 
 <%= @confirmation_url %>

--- a/app/views/spree/user_mailer/reset_password_instructions.text.erb
+++ b/app/views/spree/user_mailer/reset_password_instructions.text.erb
@@ -1,10 +1,5 @@
-A request to reset your password has been made.
-If you did not make this request, simply ignore this email.
-
-If you did make this request just click the link below:
+<%= Spree.t('user_mailer.reset_password_instructions.instructions_1') %>
 
 <%= @edit_password_reset_url %>
 
-If the above URL does not work try copying and pasting it into your browser.
-If you continue to have problems please feel free to contact us.
-
+<%= Spree.t('user_mailer.reset_password_instructions.instructions_2') %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -5,6 +5,13 @@ de:
     change_your_password: Kennwort zurücksetzen
     store_credits:
       credit_balance: Saldo des Guthabens
+    user_mailer:
+      reset_password_instructions:
+        instructions_1: "Es wurde eine Anfrage zum Zurücksetzen Ihres Passworts gestellt.\nWenn Sie diese Anfrage nicht gestellt haben, ignorieren Sie diese E-Mail.\n\nWenn Sie diese Anfrage gestellt haben, klicken Sie bitte auf den folgenden Link:"
+        instructions_2: "Falls die obige URL nicht funktioniert, bitte URL kopieren und in Ihren Browser einfügen\nWenn Sie weiterhin Probleme haben, können Sie sich gerne an uns wenden."
+      confirmation_instructions:
+        welcome: "Schön, dass Sie hier sind %{email}"
+        confirm: "Sie können Ihre Konto-E-Mail-Adresse über die folgende URL bestätigen:"
   devise:
     confirmations:
       confirmed: Ihr Konto wurde erfolgreich aktiviert.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,13 @@ en:
     change_your_password: "Change your password"
     store_credits:
       credit_balance: Store Credit Balance
+    user_mailer:
+      reset_password_instructions:
+        instructions_1: "A request to reset your password has been made.\nIf you did not make this request, simply ignore this email.\n\nIf you did make this request just click the link below:"
+        instructions_2: "If the above URL does not work try copying and pasting it into your browser.\nIf you continue to have problems please feel free to contact us."
+      confirmation_instructions:
+        welcome: "Welcome %{email}!"
+        confirm: "You can confirm your account email through the url below:"
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.

--- a/spec/controllers/spree/api/v2/storefront/passwords_controller_spec.rb
+++ b/spec/controllers/spree/api/v2/storefront/passwords_controller_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Spree::Api::V2::Storefront::PasswordsController, type: :controller do
   let(:user) { create(:user) }
   let(:password) { 'new_password' }
+  let(:store) { create(:store) }
 
   describe 'POST create' do
     before { post :create, params: params }
@@ -31,7 +32,7 @@ RSpec.describe Spree::Api::V2::Storefront::PasswordsController, type: :controlle
     context 'when updating password with blank password' do
       let(:params) {
         {
-          id: user.send_reset_password_instructions,
+          id: user.send_reset_password_instructions(Spree::Store.current),
           user: {
             password: '',
             password_confirmation: ''
@@ -48,7 +49,7 @@ RSpec.describe Spree::Api::V2::Storefront::PasswordsController, type: :controlle
     context 'when updating password with specified password' do
       let(:params) {
         {
-          id: user.send_reset_password_instructions,
+          id: user.send_reset_password_instructions(Spree::Store.current),
           user: {
             password: password,
             password_confirmation: password

--- a/spec/features/admin/sign_in_spec.rb
+++ b/spec/features/admin/sign_in_spec.rb
@@ -34,8 +34,14 @@ RSpec.feature 'Admin - Sign In', type: :feature do
     fill_in 'Email', with: user.email
     fill_in 'Password', with: 'secret'
     click_button 'Log in'
-    within '.user-menu' do
-      expect(page).to have_text 'admin@person.com'
+    if Spree.version.to_f > 4.1
+      within '.navbar .dropdown-menu' do
+        expect(page).to have_text 'admin@person.com'
+      end
+    else
+      within '.user-menu' do
+        expect(page).to have_text 'admin@person.com'
+      end
     end
     expect(current_path).to eq '/admin/orders'
   end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -35,17 +35,23 @@ RSpec.feature 'Sign In', type: :feature do
     fill_in 'Password', with: user.password
     click_button 'Log in'
 
-    within '.user-menu' do
-      expect(page).to have_text 'admin@person.com'
+    if Spree.version.to_f > 4.1
+      within '.navbar .dropdown-menu' do
+        expect(page).to have_text 'admin@person.com'
+      end
+    else
+      within '.user-menu' do
+        expect(page).to have_text 'admin@person.com'
+      end
     end
     expect(current_path).to eq '/admin/orders'
   end
 
-  xit "should store the user previous location" do
+  it 'should store the user previous location' do
     visit spree.account_path
-    fill_in "Email", with: @user.email
-    fill_in "Password", with: @user.password
-    click_button "Login"
-    expect(current_path).to eq "/account"
+    fill_in 'Email', with: @user.email
+    fill_in 'Password', with: @user.password
+    click_button 'Log in'
+    expect(current_path).to eq '/account'
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Spree::UserMailer, type: :mailer do
   describe '#reset_password_instructions' do
     describe 'message contents' do
       before do
-        @message = described_class.reset_password_instructions(user, 'token goes here')
+        @message = described_class.reset_password_instructions(user, 'token goes here', { current_store_id: Spree::Store.current.id })
       end
 
       context 'subject includes' do
@@ -30,7 +30,7 @@ RSpec.describe Spree::UserMailer, type: :mailer do
     describe 'legacy support for User object' do
       it 'sends an email' do
         expect {
-          described_class.reset_password_instructions(user, 'token goes here').deliver_now
+          described_class.reset_password_instructions(user, 'token goes here', { current_store_id: Spree::Store.current.id }).deliver_now
         }.to change(ActionMailer::Base.deliveries, :size).by(1)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Spree::User, type: :model do
   before(:all) { Spree::Role.create name: 'admin' }
+  let!(:store) { create(:store) }
 
   it '#admin?' do
     expect(create(:admin_user).admin?).to be true
@@ -8,8 +9,9 @@ RSpec.describe Spree::User, type: :model do
 
   it 'generates the reset password token' do
     user = build(:user)
-    expect(Spree::UserMailer).to receive(:reset_password_instructions).with(user, anything, {}).and_return(double(deliver: true))
-    user.send_reset_password_instructions
+    current_store = Spree::Store.current
+    expect(Spree::UserMailer).to receive(:reset_password_instructions).with(user, anything, { current_store_id: current_store.id }).and_return(double(deliver: true))
+    user.send_reset_password_instructions(current_store)
     expect(user.reset_password_token).not_to be_nil
   end
 


### PR DESCRIPTION
We need this information so an email is containing a link to the store from where the request was sent and so it has locale set to that store.