### PR TITLE
Remove unused translation

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3,8 +3,6 @@ de:
   spree:
     admin_login: Admin Login
     change_your_password: Kennwort zurücksetzen
-    store_credits:
-      credit_balance: Saldo des Guthabens
     user_mailer:
       reset_password_instructions:
         instructions_1: "Es wurde eine Anfrage zum Zurücksetzen Ihres Passworts gestellt.\nWenn Sie diese Anfrage nicht gestellt haben, ignorieren Sie diese E-Mail.\n\nWenn Sie diese Anfrage gestellt haben, klicken Sie bitte auf den folgenden Link:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,8 +3,6 @@ en:
   spree:
     admin_login: "Admin Login"
     change_your_password: "Change your password"
-    store_credits:
-      credit_balance: Store Credit Balance
     user_mailer:
       reset_password_instructions:
         welcome: "Hi %{email}"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -3,8 +3,6 @@ zh-TW:
   spree:
     admin_login: "管理員登入"
     change_your_password: "更改密碼"
-    store_credits:
-      credit_balance: 商城購物金餘額
   devise:
     confirmations:
       confirmed: 你的帳號已經確認完成，現在你已經登入網站了。


### PR DESCRIPTION
This translation is not used anymore and is overriding the `Spree` translation of the new user store credit page title.