### PR TITLE
add :lockable to spree auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,66 @@ Devise.setup do |config|
 end
 ```
 
+### Lockable
+
+To enable Devise's Lockable module, which will allow user accounts to be locked after failed retry, you can follow instructions below:
+
+* Add this line to an initializer in your Rails project (typically `config/initializers/spree.rb`)
+```ruby
+Spree::Auth::Config[:lockable] = true
+```
+
+* Add a Devise initializer to your Rails project (typically `config/initializers/devise.rb`):
+```ruby
+Devise.setup do |config|
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  config.unlock_keys = [ :email ]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  config.last_attempt_warning = true
+end
+```
+
+* Then, create the migration as:
+
+```ruby
+rails g migration add_lockable_to_spree_auth
+```
+
+* Will generate db/migrate/YYYYMMDDxxx_add_lockable_to_spree_auth.rb. Add the following to it in order to do the migration.
+
+```ruby
+class AddLockableToSpreeAuth < ActiveRecord::Migration
+  def change
+    add_column :spree_users, :failed_attempts, :integer, default: 0, null: false # Only if lock strategy is :failed_attempts
+    add_column :spree_users, :locked_at, :datetime
+
+    # Add these only if unlock strategy is :email or :both
+    add_column :spree_users, :unlock_token, :string
+    add_index :spree_users, :unlock_token, unique: true
+  end
+end
+```
 ### Sign out after password change
 
 To disable signout after password change you must add this line to an initializer in your Rails project (typically `config/initializers/spree.rb`):

--- a/app/models/spree/auth_configuration.rb
+++ b/app/models/spree/auth_configuration.rb
@@ -4,5 +4,6 @@ module Spree
     preference :signout_after_password_change, :boolean, default: true
     preference :confirmable, :boolean, default: false
     preference :validatable, :boolean, default: true
+    preference :lockable, :boolean, default: false
   end
 end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -8,6 +8,7 @@ module Spree
            :rememberable, :trackable, :encryptable, encryptor: 'authlogic_sha512'
     devise :confirmable if Spree::Auth::Config[:confirmable]
     devise :validatable if Spree::Auth::Config[:validatable]
+    devise :lockable if Spree::Auth::Config[:lockable]
 
     acts_as_paranoid
     after_destroy :scramble_email_and_password


### PR DESCRIPTION
this will allow users to use :lockable in their spree user models.
related issue:
https://github.com/spree/spree_auth_devise/issues/428
more info:
https://github.com/heartcombo/devise/wiki/How-To:-Add-:lockable-to-Users