### PR TITLE
Update Spree.t(:logged_in_successfully) spelling.

### DIFF
--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -25,7 +25,7 @@ class Spree::UserSessionsController < Devise::SessionsController
     if spree_user_signed_in?
       respond_to do |format|
         format.html {
-          flash[:success] = Spree.t(:logged_in_succesfully)
+          flash[:success] = Spree.t(:logged_in_successfully)
           redirect_back_or_default(after_sign_in_redirect(spree_current_user))
         }
         format.js {

--- a/lib/controllers/backend/spree/admin/user_sessions_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_sessions_controller.rb
@@ -14,7 +14,7 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
     if spree_user_signed_in?
       respond_to do |format|
         format.html {
-          flash[:success] = Spree.t(:logged_in_succesfully)
+          flash[:success] = Spree.t(:logged_in_successfully)
           redirect_back_or_default(after_sign_in_path_for(spree_current_user))
         }
         format.js {

--- a/lib/spree/testing_support/auth_helpers.rb
+++ b/lib/spree/testing_support/auth_helpers.rb
@@ -19,7 +19,7 @@ module Spree
         first('label', text: Spree.t(:remember_me)).click if remember_me
         click_button login_button
 
-        expect(page).to have_content Spree.t(:logged_in_succesfully)
+        expect(page).to have_content Spree.t(:logged_in_successfully)
       end
 
       def log_out


### PR DESCRIPTION
Update Spree.t(:logged_in_successfully) to match spelling in main locale file.