### PR TITLE
VEN-529 Set user variable first in UserMailer

### DIFF
--- a/lib/mailers/spree/user_mailer.rb
+++ b/lib/mailers/spree/user_mailer.rb
@@ -1,9 +1,9 @@
 module Spree
   class UserMailer < BaseMailer
     def reset_password_instructions(user, token, opts = {})
+      @user = user
       @current_store = current_store(opts)
       @edit_password_reset_url = edit_password_url(token, @current_store)
-      @user = user
 
       mail to: user.email, from: from_address, reply_to: reply_to_address,
            subject: @current_store.name + ' ' + I18n.t(:subject, scope: [:devise, :mailer, :reset_password_instructions]),


### PR DESCRIPTION
We need the user variable to be set at the beginning so that we can use it in the other methods like `current_store`