### PR TITLE
Move controller decorators into `Spree::Auth` namespace

### DIFF
--- a/lib/controllers/backend/spree/admin/resource_controller_decorator.rb
+++ b/lib/controllers/backend/spree/admin/resource_controller_decorator.rb
@@ -1,6 +1,0 @@
-module Spree::Admin::ResourceControllerDecorator
-  def self.prepended(base)
-    base.rescue_from CanCan::AccessDenied, with: :unauthorized
-  end
-end
-Spree::Admin::ResourceController.prepend(Spree::Admin::ResourceControllerDecorator)

--- a/lib/controllers/backend/spree/auth/admin/base_controller_decorator.rb
+++ b/lib/controllers/backend/spree/auth/admin/base_controller_decorator.rb
@@ -1,4 +1,4 @@
-module Spree::Admin::BaseControllerDecorator
+module Spree::Auth::Admin::BaseControllerDecorator
   # Redirect as appropriate when an access request fails.  The default action is to redirect to the login screen.
   # Override this method in your controllers if you want to have special behavior in case the user is not authorized
   # to access the requested action.  For example, a popup window might simply close itself.
@@ -22,4 +22,4 @@ module Spree::Admin::BaseControllerDecorator
     nil
   end
 end
-Spree::Admin::BaseController.prepend(Spree::Admin::BaseControllerDecorator)
+::Spree::Admin::BaseController.prepend(Spree::Auth::Admin::BaseControllerDecorator)

--- a/lib/controllers/backend/spree/auth/admin/orders/customer_details_controller_decorator.rb
+++ b/lib/controllers/backend/spree/auth/admin/orders/customer_details_controller_decorator.rb
@@ -1,4 +1,4 @@
-module Spree::Admin::Orders::CustomerDetailsControllerDecorator
+module Spree::Auth::Admin::Orders::CustomerDetailsControllerDecorator
 
   def self.prepended(base)
     base.before_action :check_authorization
@@ -17,4 +17,4 @@ module Spree::Admin::Orders::CustomerDetailsControllerDecorator
     authorize! action, resource, session[:access_token]
   end
 end
-Spree::Admin::Orders::CustomerDetailsController.prepend(Spree::Admin::Orders::CustomerDetailsControllerDecorator)
+Spree::Admin::Orders::CustomerDetailsController.prepend(Spree::Auth::Admin::Orders::CustomerDetailsControllerDecorator)

--- a/lib/controllers/backend/spree/auth/admin/orders_controller_decorator.rb
+++ b/lib/controllers/backend/spree/auth/admin/orders_controller_decorator.rb
@@ -1,4 +1,4 @@
-module Spree::Admin::OrdersControllerDecorator
+module Spree::Auth::Admin::OrdersControllerDecorator
 
   def self.prepended(base)
     base.before_action :check_authorization
@@ -22,4 +22,4 @@ module Spree::Admin::OrdersControllerDecorator
     end
   end
 end
-Spree::Admin::OrdersController.prepend(Spree::Admin::OrdersControllerDecorator)
+Spree::Admin::OrdersController.prepend(Spree::Auth::Admin::OrdersControllerDecorator)

--- a/lib/controllers/backend/spree/auth/admin/resource_controller_decorator.rb
+++ b/lib/controllers/backend/spree/auth/admin/resource_controller_decorator.rb
@@ -1,0 +1,6 @@
+module Spree::Auth::Admin::ResourceControllerDecorator
+  def self.prepended(base)
+    base.rescue_from CanCan::AccessDenied, with: :unauthorized
+  end
+end
+Spree::Admin::ResourceController.prepend(Spree::Auth::Admin::ResourceControllerDecorator)

--- a/lib/controllers/frontend/spree/auth/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/auth/checkout_controller_decorator.rb
@@ -1,5 +1,5 @@
 require 'spree/core/validators/email' if Spree.version.to_f < 3.5
-module Spree::CheckoutControllerDecorator
+module Spree::Auth::CheckoutControllerDecorator
   def self.prepended(base)
     base.before_action :check_authorization
     base.before_action :check_registration, except: [:registration, :update_registration]
@@ -42,4 +42,4 @@ module Spree::CheckoutControllerDecorator
     redirect_to spree.checkout_registration_path
   end
 end
-Spree::CheckoutController.prepend(Spree::CheckoutControllerDecorator)
+Spree::CheckoutController.prepend(Spree::Auth::CheckoutControllerDecorator)


### PR DESCRIPTION
This way we're avoiding any conflicts from developer apps using `Spree::SomeControllerDecorator`