### PR TITLE
Set devise stretches to default 10

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -37,7 +37,7 @@ Devise.setup do |config|
   # ==> Configuration for :database_authenticatable
   # For bcrypt, this is the cost for hashing the password and defaults to 10. If
   # using other encryptors, it sets how many times you want the password re-encrypted.
-  config.stretches = 20
+  config.stretches = 10
 
   # Setup a pepper to generate the encrypted password.
   #  config.pepper = '<%= SecureRandom.hex(64) %>'


### PR DESCRIPTION
I was running into a problem where logging in with a Spree user created after installing this gem was taking around 120 seconds to login in development. I _think_ this was because the devise stretches was set to 20. See this thread for more context https://github.com/heartcombo/devise/issues/1184#issuecomment-1492985.

Perhaps when this initializer was set up originally a different encryption strategy was being used and the higher stretches wasn't as slow.

To get around the issue while using this gem, just override the stretches config in a `config/devise.rb` initializer in the host app.