### PR TITLE
Check for spree_frontend gem via Gem::Specification

### DIFF
--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -57,7 +57,7 @@ module Spree
       end
 
       def self.frontend_available?
-        @@frontend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Frontend::Engine')
+        @@frontend_available ||= Gem::Specification.find_all_by_name('spree_frontend').any?
       end
 
       def self.api_available?


### PR DESCRIPTION
Currently, the `spree_auth_devise` code checks for the spree_frontend gem by checking if `Spree::Frontend::Engine` is present. This makes it so that if spree_auth_devise is listed in the gemspec before spree_frontend within a user's gemfile, the spree auth code will not find spree_frontend.

Checking for spree_frontend via `Gem::Specification` allows the code to know whether the spree_frontend gem is present whether or not it has been initialized already or not.

This fixes the broken `/account` page in the spree legacy frontend.