### PR TITLE
Add scope to routes, to unify url with frontend

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,62 +1,64 @@
 Spree::Core::Engine.add_routes do
-  devise_for :spree_user,
-            class_name: Spree.user_class.to_s,
-            controllers: { sessions: 'spree/user_sessions',
-                              registrations: 'spree/user_registrations',
-                              passwords: 'spree/user_passwords',
-                              confirmations: 'spree/user_confirmations' },
-            skip: [:unlocks, :omniauth_callbacks],
-            path_names: { sign_out: 'logout' },
-            path_prefix: :user
+  scope '(:locale)', locale: /#{Spree.available_locales.join('|')}/, defaults: { locale: nil } do
+    devise_for :spree_user,
+              class_name: Spree.user_class.to_s,
+              controllers: { sessions: 'spree/user_sessions',
+                                registrations: 'spree/user_registrations',
+                                passwords: 'spree/user_passwords',
+                                confirmations: 'spree/user_confirmations' },
+              skip: [:unlocks, :omniauth_callbacks],
+              path_names: { sign_out: 'logout' },
+              path_prefix: :user
 
-  devise_scope :spree_user do
-    get '/login' => 'user_sessions#new', :as => :login
-    post '/login' => 'user_sessions#create', :as => :create_new_session
-    get '/logout' => 'user_sessions#destroy', :as => :logout
-    get '/signup' => 'user_registrations#new', :as => :signup
-    post '/signup' => 'user_registrations#create', :as => :registration
-    get '/password/recover' => 'user_passwords#new', :as => :recover_password
-    post '/password/recover' => 'user_passwords#create', :as => :reset_password
-    get '/password/change' => 'user_passwords#edit', :as => :edit_password
-    put '/password/change' => 'user_passwords#update', :as => :update_password
-    get '/confirm' => 'user_confirmations#show', :as => :confirmation
-  end
+    devise_scope :spree_user do
+      get '/login' => 'user_sessions#new', :as => :login
+      post '/login' => 'user_sessions#create', :as => :create_new_session
+      get '/logout' => 'user_sessions#destroy', :as => :logout
+      get '/signup' => 'user_registrations#new', :as => :signup
+      post '/signup' => 'user_registrations#create', :as => :registration
+      get '/password/recover' => 'user_passwords#new', :as => :recover_password
+      post '/password/recover' => 'user_passwords#create', :as => :reset_password
+      get '/password/change' => 'user_passwords#edit', :as => :edit_password
+      put '/password/change' => 'user_passwords#update', :as => :update_password
+      get '/confirm' => 'user_confirmations#show', :as => :confirmation
+    end
 
-  if Spree::Core::Engine.frontend_available?
-    resources :users, only: [:edit, :update]
-    get '/checkout/registration' => 'checkout#registration', :as => :checkout_registration
-    put '/checkout/registration' => 'checkout#update_registration', :as => :update_checkout_registration
-    resource :account, controller: 'users'
-  end
+    if Spree::Core::Engine.frontend_available?
+      resources :users, only: [:edit, :update]
+      get '/checkout/registration' => 'checkout#registration', :as => :checkout_registration
+      put '/checkout/registration' => 'checkout#update_registration', :as => :update_checkout_registration
+      resource :account, controller: 'users'
+    end
 
-  if Spree.respond_to?(:admin_path) && Spree::Core::Engine.backend_available?
-    namespace :admin, path: Spree.admin_path do
-      devise_for :spree_user,
-                class_name: Spree.user_class.to_s,
-                controllers: { sessions: 'spree/admin/user_sessions',
-                                  passwords: 'spree/admin/user_passwords' },
-                skip: [:unlocks, :omniauth_callbacks, :registrations],
-                path_names: { sign_out: 'logout' },
-                path_prefix: :user
-      devise_scope :spree_user do
-        get '/authorization_failure', to: 'user_sessions#authorization_failure', as: :unauthorized
-        get '/login' => 'user_sessions#new', :as => :login
-        post '/login' => 'user_sessions#create', :as => :create_new_session
-        get '/logout' => 'user_sessions#destroy', :as => :logout
-        get '/password/recover' => 'user_passwords#new', :as => :recover_password
-        post '/password/recover' => 'user_passwords#create', :as => :reset_password
-        get '/password/change' => 'user_passwords#edit', :as => :edit_password
-        put '/password/change' => 'user_passwords#update', :as => :update_password
+    if Spree.respond_to?(:admin_path) && Spree::Core::Engine.backend_available?
+      namespace :admin, path: Spree.admin_path do
+        devise_for :spree_user,
+                  class_name: Spree.user_class.to_s,
+                  controllers: { sessions: 'spree/admin/user_sessions',
+                                    passwords: 'spree/admin/user_passwords' },
+                  skip: [:unlocks, :omniauth_callbacks, :registrations],
+                  path_names: { sign_out: 'logout' },
+                  path_prefix: :user
+        devise_scope :spree_user do
+          get '/authorization_failure', to: 'user_sessions#authorization_failure', as: :unauthorized
+          get '/login' => 'user_sessions#new', :as => :login
+          post '/login' => 'user_sessions#create', :as => :create_new_session
+          get '/logout' => 'user_sessions#destroy', :as => :logout
+          get '/password/recover' => 'user_passwords#new', :as => :recover_password
+          post '/password/recover' => 'user_passwords#create', :as => :reset_password
+          get '/password/change' => 'user_passwords#edit', :as => :edit_password
+          put '/password/change' => 'user_passwords#update', :as => :update_password
+        end
       end
     end
-  end
 
-  namespace :api, defaults: { format: 'json' } do
-    namespace :v2 do
-      namespace :storefront do
-        resource :account, controller: :account, only: %i[show create update]
-        resources :account_confirmations, only: %i[show]
-        resources :passwords, controller: :passwords, only: %i[create update]
+    namespace :api, defaults: { format: 'json' } do
+      namespace :v2 do
+        namespace :storefront do
+          resource :account, controller: :account, only: %i[show create update]
+          resources :account_confirmations, only: %i[show]
+          resources :passwords, controller: :passwords, only: %i[create update]
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,14 +51,14 @@ Spree::Core::Engine.add_routes do
         end
       end
     end
+  end
 
-    namespace :api, defaults: { format: 'json' } do
-      namespace :v2 do
-        namespace :storefront do
-          resource :account, controller: :account, only: %i[show create update]
-          resources :account_confirmations, only: %i[show]
-          resources :passwords, controller: :passwords, only: %i[create update]
-        end
+  namespace :api, defaults: { format: 'json' } do
+    namespace :v2 do
+      namespace :storefront do
+        resource :account, controller: :account, only: %i[show create update]
+        resources :account_confirmations, only: %i[show]
+        resources :passwords, controller: :passwords, only: %i[create update]
       end
     end
   end

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -94,7 +94,7 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
     scope = Devise::Mapping.find_scope!(resource)
     router_name = Devise.mappings[scope].router_name
     context = router_name ? send(router_name) : self
-    context.respond_to?(:login_path) ? context.login_path : "/login"
+    context.respond_to?(:login_path) ? context.login_path(locale_param) : spree.root_path
   end
 
   private

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -81,6 +81,6 @@ class Spree::UserSessionsController < Devise::SessionsController
     scope = Devise::Mapping.find_scope!(resource_or_scope)
     router_name = Devise.mappings[scope].router_name
     context = router_name ? send(router_name) : self
-    context.respond_to?(:login_path) ? context.login_path : spree.root_path
+    context.respond_to?(:login_path) ? context.login_path(locale_param) : spree.root_path
   end
 end

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
           expect(response).to redirect_to spree.checkout_registration_path
         end
 
-        context 'and locale is not default' do
+        context 'non default locale' do
           it 'redirects to registration step with non default locale' do
             get :edit, params: { state: 'address', locale: 'fr' }
             expect(response).to redirect_to spree.checkout_registration_path(locale: 'fr')
@@ -95,11 +95,8 @@ RSpec.describe Spree::CheckoutController, type: :controller do
 
         context 'non default locale' do
           it 'redirects to the tokenized order view with a non default locale' do
-            if Spree.version.to_f > 3.6
-              request.cookie_jar.signed[:token] = 'ABC'
-            else
-              request.cookie_jar.signed[:guest_token] = 'ABC'
-            end
+            # spree version higher than 3.6 required for test to work correctly
+            request.cookie_jar.signed[:token] = 'ABC'
             post :update, params: { state: 'confirm', locale: 'fr' }
             expect(response).to redirect_to spree.order_path(order, locale: 'fr')
           end
@@ -122,7 +119,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
           expect(response).to redirect_to spree.order_path(order)
         end
 
-        context 'and not deafult locale' do
+        context 'non default locale' do
           it 'redirects to the standard order view with a non default locale' do
             post :update, params: { state: 'confirm', locale: 'fr' }
             expect(response).to redirect_to spree.order_path(order, locale: 'fr')
@@ -174,9 +171,8 @@ RSpec.describe Spree::CheckoutController, type: :controller do
       expect(response).to redirect_to spree.checkout_state_path(:address)
     end
 
-    context 'and not deafult locale' do
+    context 'non default locale' do
       it 'redirects to the checkout_path after saving with non default locale' do
-        allow(order).to receive(:update) { true }
         allow(controller).to receive(:check_authorization)
         put :update_registration, params: { order: { email: 'jobs@spreecommerce.com' }, locale: 'fr' }
         expect(response).to redirect_to spree.checkout_state_path(:address, locale: 'fr')

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
           expect(response).to redirect_to spree.order_path(order)
         end
 
-        context 'and not deafult locale' do
+        context 'non default locale' do
           it 'redirects to the tokenized order view with a non default locale' do
             if Spree.version.to_f > 3.6
               request.cookie_jar.signed[:token] = 'ABC'

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
 
     context "with non default locale" do
       before do
-        Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
+        Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
       end
 
       after { I18n.locale = :en }
@@ -79,7 +79,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
 
     after { I18n.locale = :en }
 
-    it 'redirect to sign in after timeout' do
+    it 'redirects to sign in after timeout' do
       expect(controller.send(:after_inactive_sign_up_path_for, :user)).to eq(spree.login_path)
     end
 

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
     let(:user) { build_stubbed(:user) }
 
     before do 
-      Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
+      Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
       allow(Devise::Mapping).to receive(:find_scope!).and_return(:spree_user)
     end
 

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
     end
   end
   
-  context '#timeout' do
+  context 'when user session times out' do
     let(:user) { build_stubbed(:user) }
 
     before do 

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
       expect(controller.send(:after_inactive_sign_up_path_for, :user)).to eq(spree.login_path)
     end
 
-    context "with locale chagned to fr" do
+    context "with locale changed to fr" do
       before do
         allow(controller).to receive(:locale_param).and_return('fr')
       end

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -55,4 +55,27 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
       end
     end
   end
+  
+  context '#timeout' do
+    let(:user) { build_stubbed(:user) }
+
+    before do 
+      Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
+      allow(Devise::Mapping).to receive(:find_scope!).and_return(:spree_user)
+    end
+
+    it 'redirect to sign in after timeout' do
+      expect(controller.send(:after_inactive_sign_up_path_for, :user)).to eq(spree.login_path)
+    end
+
+    context "with locale chagned to fr" do
+      before do
+        allow(controller).to receive(:locale_param).and_return('fr')
+      end
+
+      it 'redirect to sign in after timeout with changed locale' do
+        expect(controller.send(:after_inactive_sign_up_path_for, :user)).to eq(spree.login_path('fr'))
+      end
+    end
+  end
 end

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -9,6 +9,19 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
       expect(response).to redirect_to spree.account_path
     end
 
+    context "with non default locale" do
+      before do
+        Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
+      end
+
+      after { I18n.locale = :en }
+
+      it 'redirects to account_path with locale' do
+        post :create, params: { spree_user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' }, locale: 'fr'}
+        expect(response).to redirect_to spree.account_path(locale: 'fr')
+      end
+    end
+
     context 'with a guest token present' do
       before do
         if Spree.version.to_f > 3.6
@@ -63,6 +76,8 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
       Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
       allow(Devise::Mapping).to receive(:find_scope!).and_return(:spree_user)
     end
+
+    after { I18n.locale = :en }
 
     it 'redirect to sign in after timeout' do
       expect(controller.send(:after_inactive_sign_up_path_for, :user)).to eq(spree.login_path)

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -203,18 +203,18 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
 
   context "#destroy" do
     before do
-      Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
+      Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
     end
 
     it "redirects to login page after signing out with default locale" do
       post :create, params: { spree_user: { email: user.email, password: 'secret' }}
-      get :destroy
+      delete :destroy
       expect(response).to redirect_to(spree.login_path)
     end
 
-    it "redirects to login page after signing out with fr locale" do
+    it "persists fr locale when redirecting to login page after signing out" do
       post :create, params: { spree_user: { email: user.email, password: 'secret' }, locale: 'fr' }
-      post :destroy, params: { locale: 'fr' }
+      delete :destroy, params: { locale: 'fr' }
       expect(response).to redirect_to spree.login_path(locale: 'fr')
     end
 end

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -200,4 +200,22 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
       end
     end
   end
+
+  context "#destroy" do
+    before do
+      Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
+    end
+
+    it "redirects to login page after signing out with deafult locale" do
+      post :create, params: { spree_user: { email: user.email, password: 'secret' }}
+      get :destroy
+      expect(response).to redirect_to(spree.login_path)
+    end
+
+    it "redirects to login page after signing out with fr locale" do
+      post :create, params: { spree_user: { email: user.email, password: 'secret' }, locale: 'fr' }
+      post :destroy, params: { locale: 'fr' }
+      expect(response).to redirect_to spree.login_path(locale: 'fr')
+    end
+end
 end

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
       Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
     end
 
-    it "redirects to login page after signing out with deafult locale" do
+    it "redirects to login page after signing out with default locale" do
       post :create, params: { spree_user: { email: user.email, password: 'secret' }}
       get :destroy
       expect(response).to redirect_to(spree.login_path)

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -3,13 +3,24 @@ RSpec.describe Spree::UsersController, type: :controller do
   let(:user) { create(:user) }
   let(:role) { create(:role) }
 
-  before { allow(controller).to receive(:spree_current_user) { user } }
+  before do 
+    allow(controller).to receive(:spree_current_user) { user }
+    Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
+  end
 
   context '#load_object' do
     it 'redirects to signup path if user is not found' do
       allow(controller).to receive(:spree_current_user) { nil }
       put :update, params: { user: { email: 'foobar@example.com' } }
       expect(response).to redirect_to spree.login_path
+    end
+
+    context "and locale is not default" do
+      it 'redirects to signup path with non default locale if user is not found' do
+        allow(controller).to receive(:spree_current_user) { nil }
+        put :update, params: { user: { email: 'foobar@example.com' }, locale: 'fr' }
+        expect(response).to redirect_to spree.login_path(locale: 'fr')
+      end
     end
   end
 
@@ -26,6 +37,14 @@ RSpec.describe Spree::UsersController, type: :controller do
         put :update, params: { user: { email: 'mynew@email-address.com' } }
         expect(assigns[:user].email).to eq 'mynew@email-address.com'
         expect(response).to redirect_to spree.account_path
+      end
+
+      context 'and locale is not default' do
+        it 'performs update' do
+          put :update, params: { user: { email: 'mynew@email-address.com' }, locale: 'fr' }
+          expect(assigns[:user].email).to eq 'mynew@email-address.com'
+          expect(response).to redirect_to spree.account_path(locale: 'fr')
+        end
       end
     end
 

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Spree::UsersController, type: :controller do
 
   before do 
     allow(controller).to receive(:spree_current_user) { user }
-    Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr') if Spree.version.to_f >= 4.2
+    Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
   end
 
   context '#load_object' do
@@ -15,7 +15,7 @@ RSpec.describe Spree::UsersController, type: :controller do
       expect(response).to redirect_to spree.login_path
     end
 
-    context "and locale is not default" do
+    context "non default locale" do
       it 'redirects to signup path with non default locale if user is not found' do
         allow(controller).to receive(:spree_current_user) { nil }
         put :update, params: { user: { email: 'foobar@example.com' }, locale: 'fr' }
@@ -39,10 +39,14 @@ RSpec.describe Spree::UsersController, type: :controller do
         expect(response).to redirect_to spree.account_path
       end
 
-      context 'and locale is not default' do
+      context 'non default locale' do
+        before { put :update, params: { user: { email: 'mynew@email-address.com' }, locale: 'fr' } }
+
         it 'performs update' do
-          put :update, params: { user: { email: 'mynew@email-address.com' }, locale: 'fr' }
           expect(assigns[:user].email).to eq 'mynew@email-address.com'
+        end
+
+        it 'persists locale when redirecting to account' do
           expect(response).to redirect_to spree.account_path(locale: 'fr')
         end
       end

--- a/spec/features/admin/sign_in_spec.rb
+++ b/spec/features/admin/sign_in_spec.rb
@@ -18,6 +18,27 @@ RSpec.feature 'Admin - Sign In', type: :feature do
     expect(current_path).to eq '/account'
   end
 
+  context 'localized' do
+    before do
+      if Spree.version.to_f >= 4.2
+        add_french_locales
+        Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
+        I18n.locale = :fr
+      end
+    end
+
+    after { I18n.locale = :en }
+
+    scenario 'lets a user sign in successfully', js: true do
+      log_in(email: @user.email, password: 'secret', locale: 'fr')
+      show_user_menu
+  
+      expect(page).not_to have_text login_button.upcase
+      expect(page).to have_text logout_button.upcase
+      expect(current_path).to eq '/fr/account'
+    end
+  end
+
   scenario 'shows validation errors' do
     fill_in 'Email', with: @user.email
     fill_in 'Password', with: 'wrong_password'

--- a/spec/features/admin/sign_in_spec.rb
+++ b/spec/features/admin/sign_in_spec.rb
@@ -18,13 +18,11 @@ RSpec.feature 'Admin - Sign In', type: :feature do
     expect(current_path).to eq '/account'
   end
 
-  context 'localized' do
+  context 'with non default locale' do
     before do
-      if Spree.version.to_f >= 4.2
-        add_french_locales
-        Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
-        I18n.locale = :fr
-      end
+      add_french_locales
+      Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
+      I18n.locale = :fr
     end
 
     after { I18n.locale = :en }

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'Sign In', type: :feature do
 
       expect(page).not_to have_text Spree.t(:login).upcase
       expect(page).to have_text Spree.t(:logout).upcase
-      expect(current_url).to match(/\/account\?locale\=fr$/)
+      expect(current_url).to match(/\/fr\/account/)
     end
   end
 end


### PR DESCRIPTION
Change locale from being in url as param, to being part of url, using scope in routes.
It will break locale for legacy_frontend however (they'll be lost while clicking log out etc.), without this fix https://github.com/spree/spree_legacy_frontend/pull/31.