### PR TITLE
Unify method for checking for spree gems

### DIFF
--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -49,23 +49,19 @@ module Spree
       end
 
       def self.api_available?
-        @@api_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Api::Engine')
+        @@api_available ||= Gem::Specification.find_all_by_name('spree').any?
       end
 
       def self.backend_available?
-        @@backend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Backend::Engine')
+        @@backend_available ||= Gem::Specification.find_all_by_name('spree_backend').any?
       end
 
       def self.frontend_available?
-        @@frontend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Frontend::Engine')
-      end
-
-      def self.api_available?
-        @@api_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Api::Engine')
+        @@frontend_available ||= Gem::Specification.find_all_by_name('spree_frontend').any?
       end
 
       def self.emails_available?
-        @@emails_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Emails::Engine')
+        @@emails_available ||= Gem::Specification.find_all_by_name('spree_emails').any?
       end
 
       if backend_available?


### PR DESCRIPTION
Method for checking if the `spree_frontend` gem was changed to handle an error occurring when `spree_frontend` was included before `spree_auth_devise` gem.

Update the method for checking all other spree gems to also use `Gem::Specification`. Also remove duplicate method definition for `api_available?`.

Integration with legacy frontend still needs to be tested locally.