### PR TITLE
Don't set Spree.user_class unless it's blank

### DIFF
--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -14,7 +14,7 @@ module Spree
       end
 
       initializer "spree_auth_devise.set_user_class", after: :load_config_initializers do
-        Spree.user_class = 'Spree::User'
+        Spree.user_class = 'Spree::User' if Spree.user_class.blank? || Spree.user_class.to_s == 'Spree::LegacyUser'
       end
 
       initializer "spree_auth_devise.check_secret_token" do


### PR DESCRIPTION
This line was changed March 28, 2022 and overrides the `Spree.user_class`, even if it's already been set to a custom user in the host app's `Spree.rb` file https://github.com/spree/spree_auth_devise/commit/0a45ca07cdb0976281500ccfd231483d3a6c0611#diff-8d002d054349f039bafc03785a785a1594ef6b4539298f59e84e95217a97abedL17. 

I don't see why this would be desirable, so I suggest reverting it. 