### PR TITLE
save current locale during registration

### DIFF
--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -30,6 +30,7 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   # POST /resource/sign_up
   def create
     @user = build_resource(spree_user_params)
+    @user.saved_locale = current_locale
     resource.skip_confirmation_notification! if Spree::Auth::Config[:confirmable]
     resource_saved = resource.save
     yield resource if block_given?

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 class Spree::UserRegistrationsController < Devise::RegistrationsController
   helper 'spree/base'
 
@@ -30,7 +32,6 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   # POST /resource/sign_up
   def create
     @user = build_resource(spree_user_params)
-    @user.selected_locale = current_locale
     resource.skip_confirmation_notification! if Spree::Auth::Config[:confirmable]
     resource_saved = resource.save
     yield resource if block_given?
@@ -105,7 +106,9 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   end
 
   def spree_user_params
-    params.require(:spree_user).permit(Spree::PermittedAttributes.user_attributes)
+    user_params = params.require(:spree_user).permit(Spree::PermittedAttributes.user_attributes)
+    user_params[:selected_locale] = current_locale
+    user_params
   end
 
   def after_sign_in_redirect(resource_or_scope)

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 class Spree::UserRegistrationsController < Devise::RegistrationsController
   helper 'spree/base'
 

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -30,7 +30,7 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   # POST /resource/sign_up
   def create
     @user = build_resource(spree_user_params)
-    @user.saved_locale = current_locale
+    @user.selected_locale = current_locale
     resource.skip_confirmation_notification! if Spree::Auth::Config[:confirmable]
     resource_saved = resource.save
     yield resource if block_given?

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
       expect(response).to redirect_to spree.account_path
     end
 
-    context "with non default locale" do
+    context 'with non default locale' do
       before do
         Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
       end
@@ -19,6 +19,12 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
       it 'redirects to account_path with locale' do
         post :create, params: { spree_user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' }, locale: 'fr'}
         expect(response).to redirect_to spree.account_path(locale: 'fr')
+      end
+
+      it 'saves locale in user' do
+        post :create, params: { spree_user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' }, locale: 'fr'}
+        user = Spree.user_class.find_by_email('foobar@example.com')
+        expect(user.selected_locale).to eq('fr')
       end
     end
 
@@ -68,11 +74,11 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
       end
     end
   end
-  
+
   context 'when user session times out' do
     let(:user) { build_stubbed(:user) }
 
-    before do 
+    before do
       Spree::Store.default.update(default_locale: 'en', supported_locales: 'en,fr')
       allow(Devise::Mapping).to receive(:find_scope!).and_return(:spree_user)
     end
@@ -83,7 +89,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
       expect(controller.send(:after_inactive_sign_up_path_for, :user)).to eq(spree.login_path)
     end
 
-    context "with locale changed to fr" do
+    context 'with locale changed to fr' do
       before do
         allow(controller).to receive(:locale_param).and_return('fr')
       end

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -33,22 +33,33 @@ RSpec.describe Spree::UsersController, type: :controller do
 
   context '#update' do
     context 'when updating own account' do
-      it 'performs update' do
-        put :update, params: { user: { email: 'mynew@email-address.com' } }
-        expect(assigns[:user].email).to eq 'mynew@email-address.com'
-        expect(response).to redirect_to spree.account_path
+      context 'deafult locale' do
+        before { put :update, params: { user: { email: 'mynew@email-address.com' } } }
+
+        it 'performs update of email' do
+          expect(assigns[:user].email).to eq 'mynew@email-address.com'
+        end
+
+        it 'redirects to correct path' do
+          expect(response).to redirect_to spree.account_path
+        end
       end
 
       context 'non default locale' do
         before { put :update, params: { user: { email: 'mynew@email-address.com' }, locale: 'fr' } }
 
-        it 'performs update' do
+        it 'performs update of email' do
           expect(assigns[:user].email).to eq 'mynew@email-address.com'
         end
 
         it 'persists locale when redirecting to account' do
           expect(response).to redirect_to spree.account_path(locale: 'fr')
         end
+      end
+
+      it 'performs update of selected_locale' do
+        put :update, params: { user: { selected_locale: 'pl' } }
+        expect(assigns[:user].selected_locale).to eq 'pl'
       end
     end
 


### PR DESCRIPTION
During registration set param saved_locale to current_locale.

Adds columns called "saved_locale" to User in databse. 

It's part of bigger set of changes meant to allow storing locale in user and retrieving it whenever user is revisiting a page/when we're meant to send them an email etc.
See also:
- https://github.com/spree/spree/pull/11814
- https://github.com/spree/spree_legacy_frontend/pull/42
- https://github.com/spree/spree_starter/pull/1039