### PR TITLE
Allows use of stand-alone Spree Checkout

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,19 @@ Spree::Core::Engine.add_routes do
 
     if Spree::Core::Engine.frontend_available?
       resources :users, only: [:edit, :update]
-      get '/checkout/registration' => 'checkout#registration', :as => :checkout_registration
-      put '/checkout/registration' => 'checkout#update_registration', :as => :update_checkout_registration
       resource :account, controller: 'users'
+
+      unless Spree::Auth::Engine.checkout_available?
+        get '/checkout/registration' => 'checkout#registration', :as => :checkout_registration
+        put '/checkout/registration' => 'checkout#update_registration', :as => :update_checkout_registration
+      end
+    end
+
+    if Spree::Auth::Engine.checkout_available?
+      namespace :checkout do
+        get :registration, to: 'orders#registration', as: :registration
+        put :registration, to: 'orders#update_registration', as: :update_registration
+      end
     end
 
     if Spree.respond_to?(:admin_path) && Spree::Core::Engine.backend_available?

--- a/lib/controllers/checkout/spree/auth/checkout/orders_controller_decorator.rb
+++ b/lib/controllers/checkout/spree/auth/checkout/orders_controller_decorator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Spree
+  module Auth
+    module Checkout
+      #
+      # Adds methods to Spree Checkout Orders
+      module OrdersControllerDecorator
+        def self.prepended(base)
+          base.before_action :check_authorization
+          base.before_action :check_registration, except: %i[registration update_registration]
+        end
+
+        def registration
+          @user = Spree.user_class.new
+          @title = Spree.t(:registration)
+        end
+
+        def update_registration
+          if order_params[:email] =~ Devise.email_regexp && current_order.update_attribute(:email, order_params[:email])
+            redirect_to spree.checkout_state_path(:address)
+          else
+            flash[:error] = t(:email_is_invalid, scope: %i[errors messages])
+            @user = Spree.user_class.new
+            render 'registration', status: :unprocessable_entity
+          end
+        end
+
+        private
+
+        def order_params
+          params[:order].present? ? params.require(:order).permit(:email) : {}
+        end
+
+        def skip_state_validation?
+          %w[registration update_registration].include?(params[:action])
+        end
+
+        def check_authorization
+          authorize!(:edit, current_order, cookies.signed[:guest_token])
+        end
+
+        # Introduces a registration step whenever the +registration_step+ preference is true.
+        def check_registration
+          return unless Spree::Auth::Config[:registration_step]
+          return if spree_current_user || current_order.email
+
+          store_location
+          redirect_to spree.checkout_registration_path
+        end
+
+        Spree::Checkout::OrdersController.prepend(self) if ::Spree::Checkout::OrdersController.included_modules.exclude?(self)
+      end
+    end
+  end
+end

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -48,8 +48,8 @@ module Spree
         ApplicationController.send :include, Spree::AuthenticationHelpers
       end
 
-      def self.api_available?
-        @@api_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Api::Engine')
+      def self.checkout_available?
+        @@checkout_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Checkout::Engine')
       end
 
       def self.backend_available?


### PR DESCRIPTION
This PR add the ability to use a stand alone Spree Checkout.

1. Checks to see if the app is using the `Spree::Checkout`
2. Uses routes to the name spaced `Spree::Checkout`
3. Adds the Login redirect logic to the name spaced `Spree::Checkout::OrdersController` controller
