### PR TITLE
Fix engine configuration

### DIFF
--- a/lib/spree/auth/configuration.rb
+++ b/lib/spree/auth/configuration.rb
@@ -1,10 +1,33 @@
 module Spree
   module Auth
-    class Configuration < Preferences::Configuration
-      preference :registration_step, :boolean, default: true
-      preference :signout_after_password_change, :boolean, default: true
-      preference :confirmable, :boolean, default: false
-      preference :validatable, :boolean, default: true
+    class Configuration
+      attr_accessor :registration_step,
+                    :signout_after_password_change,
+                    :confirmable,
+                    :validatable
+
+      def initialize
+        self.registration_step = true
+        self.signout_after_password_change = true
+        self.confirmable = false
+        self.validatable = true
+      end
+
+      def configure
+        yield(self) if block_given?
+      end
+
+      def get(preference)
+        send(preference)
+      end
+
+      alias [] get
+
+      def set(preference, value)
+        send("#{preference}=", value)
+      end
+
+      alias []= set
     end
   end
 end

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
     context 'when registration step enabled' do
       before do
         allow(controller).to receive(:check_authorization)
-        Spree::Auth::Config.set(registration_step: true)
+        Spree::Auth::Config.set(:registration_step, true)
       end
 
       context 'when authenticated as registered user' do
@@ -42,7 +42,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
 
     context 'when registration step disabled' do
       before do
-        Spree::Auth::Config.set(registration_step: false)
+        Spree::Auth::Config.set(:registration_step, false)
         allow(controller).to receive(:check_authorization)
       end
 

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Checkout', :js, type: :feature do
     end
 
     scenario 'allow a visitor to checkout as guest, without registration' do
-      Spree::Auth::Config.set(registration_step: true)
+      Spree::Auth::Config.set(:registration_step, true)
       add_to_cart(mug)
       click_link 'checkout'
 

--- a/spec/support/configuration_helpers.rb
+++ b/spec/support/configuration_helpers.rb
@@ -1,6 +1,6 @@
 module ConfigurationHelpers
   def allow_bypass_sign_in
-    Spree::Auth::Config.set(signout_after_password_change: false)
+    Spree::Auth::Config.set(:signout_after_password_change, false)
   end
 end
 

--- a/spec/support/confirm_helpers.rb
+++ b/spec/support/confirm_helpers.rb
@@ -1,12 +1,14 @@
 RSpec.configure do |config|
   config.around do |example|
     if example.metadata.key?(:confirmable)
+      old_setting = Spree::Auth::Config.confirmable
       old_user = Spree::User
 
       begin
         example.run
       ensure
         Spree.const_set('User', old_user)
+        Spree::Auth::Config.confirmable = old_setting
       end
     else
       example.run
@@ -16,7 +18,7 @@ RSpec.configure do |config|
   config.before do |example|
     if example.metadata.key?(:confirmable)
       Rails.cache.clear
-      Spree::Auth::Config[:confirmable] = example.metadata[:confirmable]
+      Spree::Auth::Config.confirmable = example.metadata[:confirmable]
 
       Spree.send(:remove_const, :User)
       load File.expand_path('../../../app/models/spree/user.rb', __FILE__)


### PR DESCRIPTION
Fixes https://github.com/spree/spree/issues/11933
In short, the previous solution persisted these preferences in the database. It doesn't make much sense, since this is not something that can be configured via the admin panel.

I've extracted it to a simple object that conforms to the old interface, but doesn't rely on the database.