### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,55 +9,11 @@ defaults: &defaults
     BUNDLE_PATH: ~/spree/vendor/bundle
   working_directory: ~/spree
   docker:
-    - image: &ruby_image circleci/ruby:2.7-node-browsers
+    - image: &ruby_image circleci/ruby:3.0-node-browsers
     - image: &redis_image circleci/redis:6.2-alpine
-
-defaults_3_0: &defaults_3_0
-  <<: *defaults
-  docker:
-    - image: &ruby_3_0_image circleci/ruby:3.0-node-browsers
-    - image: *redis_image
 
 run_tests: &run_tests
   <<: *defaults
-  steps:
-    - checkout
-    - restore_cache:
-        keys:
-          - spree-auth-devise-bundle-v9-ruby-2-7-{{ .Branch }}
-          - spree-auth-devise-bundle-v9-ruby-2-7
-    - run:
-        name: Add keyserver
-        command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-    - run:
-        name: Install libvips
-        command: sudo apt-get update && sudo apt-get install libvips
-    - run:
-        name: Set bundle path
-        command: bundle config --local path vendor/bundle
-    - run:
-        name: Ensure bundle Install
-        command: |
-          bundle check || bundle install
-    - run:
-        name: Create test app
-        command: |
-          bundle exec rake test_app
-    - run:
-        name: Run Rspec
-        command: |
-          TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-          bundle exec rspec --format documentation \
-                            --format RspecJunitFormatter \
-                            -o ~/rspec/rspec.xml \
-                            -- ${TESTFILES}
-    - store_test_results:
-        path: ~/rspec
-    - store_artifacts:
-        path: tmp/capybara
-
-run_tests_3_0: &run_tests_3_0
-  <<: *defaults_3_0
   steps:
     - checkout
     - restore_cache:
@@ -101,32 +57,6 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - spree-auth-devise-bundle-v9-ruby-2-7-{{ .Branch }}
-            - spree-auth-devise-bundle-v9-ruby-2-7
-      - run:
-          name: Add keyserver
-          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-      - run:
-          name: Install libvips
-          command: sudo apt-get update && sudo apt-get install libvips
-      - run:
-          name: Set bundle path
-          command: bundle config --local path vendor/bundle
-      - run:
-          name: Bundle Install
-          command: |
-            bundle check || bundle install
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: spree-auth-devise-bundle-v9-ruby-2-7-{{ checksum "Gemfile.lock" }}
-
-  bundle_ruby_3_0:
-    <<: *defaults_3_0
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
             - spree-auth-devise-bundle-v9-ruby-3-0-{{ .Branch }}
             - spree-auth-devise-bundle-v9-ruby-3-0
       - run:
@@ -161,15 +91,6 @@ jobs:
         environment:
           POSTGRES_USER: postgres
 
-  tests_postgres_ruby_3_0: &tests_postgres_ruby_3_0
-    <<: *run_tests_3_0
-    environment:
-      <<: *postgres_environment
-    docker:
-      - image: *ruby_3_0_image
-      - image: *postgres_image
-      - image: *redis_image
-
   tests_mysql: &tests_mysql
     <<: *run_tests
     environment: &mysql_environment
@@ -189,13 +110,9 @@ workflows:
   main:
     jobs:
       - bundle
-      - bundle_ruby_3_0
       - tests_postgres:
           requires:
             - bundle
-      - tests_postgres_ruby_3_0:
-          requires:
-            - bundle_ruby_3_0
       - tests_mysql:
           requires:
             - bundle


### PR DESCRIPTION
Ruby 2.7 is no longer supported, and will be unsupported for Spree 5.x. This PR removes tests running pipelines using Ruby 2.7