### PR TITLE
Allow turning on/off different devise features

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -7,8 +7,11 @@ module Spree
       include Metadata
     end
 
-    devise :database_authenticatable, :registerable, :recoverable,
-           :rememberable, :trackable, :encryptable, encryptor: 'authlogic_sha512'
+    devise :rememberable, :trackable, :encryptable, encryptor: 'authlogic_sha512'
+
+    devise :database_authenticatable if Spree::Auth::Config[:database_authenticatable]
+    devise :recoverable if Spree::Auth::Config[:recoverable]
+    devise :registerable if Spree::Auth::Config[:registerable]
     devise :confirmable if Spree::Auth::Config[:confirmable]
     devise :validatable if Spree::Auth::Config[:validatable]
 

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -3,17 +3,15 @@ module Spree
     include UserAddress
     include UserMethods
     include UserPaymentSource
-    if defined?(Spree::Metadata)
-      include Metadata
-    end
-
-    devise :rememberable, :trackable, :encryptable, encryptor: 'authlogic_sha512'
+    include Metadata if defined?(Spree::Metadata)
 
     devise :database_authenticatable if Spree::Auth::Config[:database_authenticatable]
     devise :recoverable if Spree::Auth::Config[:recoverable]
     devise :registerable if Spree::Auth::Config[:registerable]
     devise :confirmable if Spree::Auth::Config[:confirmable]
     devise :validatable if Spree::Auth::Config[:validatable]
+
+    devise :rememberable, :trackable, :encryptable, encryptor: 'authlogic_sha512'
 
     acts_as_paranoid
     after_destroy :scramble_email_and_password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,16 +11,29 @@ Spree::Core::Engine.add_routes do
               path_prefix: :user
 
     devise_scope :spree_user do
-      get '/login' => 'user_sessions#new', :as => :login
-      post '/login' => 'user_sessions#create', :as => :create_new_session
       get '/logout' => 'user_sessions#destroy', :as => :logout
-      get '/signup' => 'user_registrations#new', :as => :signup
-      post '/signup' => 'user_registrations#create', :as => :registration
-      get '/password/recover' => 'user_passwords#new', :as => :recover_password
-      post '/password/recover' => 'user_passwords#create', :as => :reset_password
-      get '/password/change' => 'user_passwords#edit', :as => :edit_password
-      put '/password/change' => 'user_passwords#update', :as => :update_password
-      get '/confirm' => 'user_confirmations#show', :as => :confirmation
+
+      if Spree::Auth::Config[:database_authenticatable]
+        get '/login' => 'user_sessions#new', :as => :login
+        post '/login' => 'user_sessions#create', :as => :create_new_session
+
+        get '/password/change' => 'user_passwords#edit', :as => :edit_password
+        put '/password/change' => 'user_passwords#update', :as => :update_password
+      end
+
+      if Spree::Auth::Config[:registerable]
+        get '/signup' => 'user_registrations#new', :as => :signup
+        post '/signup' => 'user_registrations#create', :as => :registration
+      end
+
+      if Spree::Auth::Config[:recoverable]
+        get '/password/recover' => 'user_passwords#new', :as => :recover_password
+        post '/password/recover' => 'user_passwords#create', :as => :reset_password
+      end
+
+      if Spree::Auth::Config[:confirmable]
+        get '/confirm' => 'user_confirmations#show', :as => :confirmation
+      end
     end
 
     if Spree::Core::Engine.frontend_available?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,12 +46,13 @@ Spree::Core::Engine.add_routes do
     if Spree.respond_to?(:admin_path) && Spree::Core::Engine.backend_available?
       namespace :admin, path: Spree.admin_path do
         devise_for :spree_user,
-                  class_name: Spree.user_class.to_s,
+                  class_name: Spree.admin_user_class.to_s,
                   controllers: { sessions: 'spree/admin/user_sessions',
-                                    passwords: 'spree/admin/user_passwords' },
+                                   passwords: 'spree/admin/user_passwords' },
                   skip: [:unlocks, :omniauth_callbacks, :registrations],
                   path_names: { sign_out: 'logout' },
                   path_prefix: :user
+
         devise_scope :spree_user do
           get '/authorization_failure', to: 'user_sessions#authorization_failure', as: :unauthorized
           get '/login' => 'user_sessions#new', :as => :login

--- a/lib/spree/auth/configuration.rb
+++ b/lib/spree/auth/configuration.rb
@@ -4,12 +4,18 @@ module Spree
       attr_accessor :registration_step,
                     :signout_after_password_change,
                     :confirmable,
+                    :database_authenticatable,
+                    :recoverable,
+                    :registerable,
                     :validatable
 
       def initialize
         self.registration_step = true
         self.signout_after_password_change = true
         self.confirmable = false
+        self.database_authenticatable = true
+        self.recoverable = true
+        self.registerable = true
         self.validatable = true
       end
 

--- a/lib/views/frontend/spree/user_sessions/new.html.erb
+++ b/lib/views/frontend/spree/user_sessions/new.html.erb
@@ -8,7 +8,7 @@
           <div data-hook="login_extras"></div>
         </div>
 
-        <% if Spree::Auth::Config[:registrable] %>
+        <% if Spree::Auth::Config[:registerable] %>
           <div class="col-lg-11 mx-auto" data-hook="registration">
             <%= render partial: 'spree/shared/registration', locals: { registration_button: 'registration-button' } %>
           </div>

--- a/lib/views/frontend/spree/user_sessions/new.html.erb
+++ b/lib/views/frontend/spree/user_sessions/new.html.erb
@@ -7,9 +7,12 @@
           <%= render partial: 'spree/shared/login' %>
           <div data-hook="login_extras"></div>
         </div>
-        <div class="col-lg-11 mx-auto" data-hook="registration">
-          <%= render partial: 'spree/shared/registration', locals: { registration_button: 'registration-button' } %>
-        </div>
+
+        <% if Spree::Auth::Config[:registrable] %>
+          <div class="col-lg-11 mx-auto" data-hook="registration">
+            <%= render partial: 'spree/shared/registration', locals: { registration_button: 'registration-button' } %>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -106,6 +106,8 @@ RSpec.describe Spree::User, type: :model do
   describe "#send_confirmation_instructions", retry: 2 do
     let(:default_store) { Spree::Store.default }
 
+    before { Rails.application.reload_routes! }
+
     context "when current store not exists" do
       it 'takes default store and sends confirmation instruction', confirmable: true do
         user = Spree.user_class.new


### PR DESCRIPTION
Our need is to create a shop where you can only login through our oauth2 omniauth endpoints and not allow logging in with a password or to create the user.